### PR TITLE
Use name instead of title to load extension

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -80,7 +80,7 @@ define php::extension(
 
   $lowercase_title = downcase($title)
   $real_config = $provider ? {
-    'pecl'  => concat(["set .anon/extension '${title}.so'"], $config),
+    'pecl'  => concat(["set .anon/extension '${name}.so'"], $config),
     default => $config
   }
   $php_config_file = "${php::params::config_root_ini}/${lowercase_title}.ini"


### PR DESCRIPTION
Backwards-compatible fix for https://github.com/Mayflower/puppet-php/issues/19
