### PR TITLE
Fix hardcoded php.ini path

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -29,7 +29,7 @@
 class php::cli(
   $ensure   = 'installed',
   $package  = $php::params::cli_package,
-  $inifile  = '/etc/php5/cli/php.ini',
+  $inifile  = $php::params::cli_inifile,
   $settings = {}
 ) inherits php::params {
 


### PR DESCRIPTION
Use `$php::params::cli_inifile` instead of hardcoded value.
