### PR TITLE
Mods

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -42,7 +42,10 @@ class php::cli(
   validate_absolute_path($inifile)
   validate_hash($settings)
 
-  $real_settings = merge($settings, hiera_hash('php::cli::settings', {}))
+  $real_settings = hiera('php::cli::settings', false) ? {
+    false   => $settings,
+    default => merge($settings, hiera_hash('php::cli::settings'))
+  }
 
   package { $package:
     ensure  => $ensure,

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -35,7 +35,10 @@ class php::fpm(
   validate_hash($settings)
   validate_hash($pools)
 
-  $real_settings = merge($settings, hiera_hash('php::fpm::settings', {}))
+  $real_settings = hiera('php::fpm::settings', false) ? {
+    false   => $settings,
+    default => merge(hiera_hash('php::fpm::settings'), $settings)
+  }
 
   anchor { 'php::fpm::begin': } ->
     class { 'php::fpm::package':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,9 +123,16 @@ class php (
 
   # FIXME: for deep merging support we need a explicit hash lookup instead of automatic parameter lookup
   #        (https://tickets.puppetlabs.com/browse/HI-118)
-  $real_settings = hiera_hash('php::settings', $settings)
+  $real_settings = hiera('php::settings', false) ? {
+    false   => $settings,
+    default => merge(hiera_hash('php::settings'), $settings)
+  }
 
-  $real_extensions = hiera_hash('php::extensions', $extensions)
+  $real_extensions = hiera('php::extensions', false) ? {
+    false   => $extensions,
+    default => merge(hiera_hash('php::extensions'), $extensions)
+  }
+
   create_resources('php::extension', $real_extensions, {
     ensure  => $ensure,
     before  => Anchor['php::end']


### PR DESCRIPTION
two changes: 
1. php::cli is also optional now
2. changed param lookup mechanism

The background for the 2nd change is that (at least on our systems, puppet 3.4.2 with hiera 1.3.1) `hiera_hash('my_lookup', {})` always fails if the key cannot be found in hiera. `hiera('my_lookup', false)` works, though.
