### PR TITLE
Retarget dependency requirement from package parameter to package class

### DIFF
--- a/manifests/composer.pp
+++ b/manifests/composer.pp
@@ -45,9 +45,7 @@ class php::composer (
     command => "wget ${source} -O ${path}",
     creates => $path,
     path    => ['/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/'],
-    require => [
-      Package[$php::params::cli_package]
-    ]
+    require => Class['php::cli'],
   } ->
   file { $path:
     mode  => '0555',

--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -37,7 +37,7 @@ class php::fpm::service(
     enable    => $enable,
     restart   => "service ${service_name} reload",
     hasstatus => true,
-    require   => Package[$php::params::fpm_package],
+    require   => Class['php::fpm::package'],
   }
 
   Php::Extension <| |> ~> Service[$service_name]


### PR DESCRIPTION
This lets you override the default cli or fpm package parameters without breaking dependencies for composer or the fpm service.
