### PR TITLE
Install phpunit from the phar

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,9 @@ class php::params {
   $composer_source    = 'https://getcomposer.org/composer.phar'
   $composer_path      = '/usr/local/bin/composer'
   $composer_max_age   = 30
+  $phpunit_source    = 'https://phar.phpunit.de/phpunit.phar'
+  $phpunit_path      = '/usr/local/bin/phpunit'
+  $phpunit_max_age   = 30
 
   case $::osfamily {
     'Debian': {

--- a/manifests/phpunit.pp
+++ b/manifests/phpunit.pp
@@ -1,14 +1,20 @@
 # == Class: php::phpunit
 #
-# Install phpunit, PHP testing framework via PEAR, this will be changed to use composer
+# Install phpunit, PHP testing framework
 #
 # === Parameters
 #
-# [*package*]
-#   The package name for PHPUnit, defaults to phpunit's pear package
+# [*source*]
+# Holds URL to the phpunit source file
 #
-# [*provider*]
-#   The package provider used to install PHPUnit, defaults to pear
+# [*path*]
+# Holds path to the phpunit executable
+#
+# [*auto_update*]
+# defines if phpunit should be auto updated
+#
+# [*max_age*]
+# defines the time in days after which an auto-update gets executed
 #
 # === Authors
 #
@@ -20,25 +26,39 @@
 #
 # See LICENSE file
 #
-
-#FIXME: no pear
 class php::phpunit (
-  $package  = 'pear.phpunit.de/PHPUnit',
-  $provider = 'pear',
-) {
+  $source      = $php::params::phpunit_source,
+  $path        = $php::params::phpunit_path,
+  $auto_update = true,
+  $max_age     = $php::params::phpunit_max_age,
+) inherits php::params {
 
   if $caller_module_name != $module_name {
     warning("${name} is not part of the public API of the ${module_name} module and should not be directly included in the manifest.")
   }
 
-  validate_string($package)
+  validate_string($source)
+  validate_absolute_path($path)
+  validate_bool($auto_update)
+  validate_re("${max_age}", '^\d+$')
 
-  package { $package:
-    ensure   => present,
-    provider => $provider,
+  exec { 'download phpunit':
+    command => "wget ${source} -O ${path}",
+    creates => $path,
+    path    => ['/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/'],
+    require => Class['php::cli'],
+  } ->
+  file { $path:
+    mode  => '0555',
+    owner => root,
+    group => root,
   }
 
-  if $provider == 'pear' {
-    Exec['php::pear::auto_discover'] -> Package[$package]
+  if $auto_update {
+    class { 'php::phpunit::auto_update':
+      max_age => $max_age,
+      source  => $source,
+      path    => $path
+    }
   }
 }

--- a/manifests/phpunit/auto_update.pp
+++ b/manifests/phpunit/auto_update.pp
@@ -1,0 +1,48 @@
+# == Class: php::phpunit::auto_update
+#
+# Install phpunit package manager
+#
+# === Parameters
+#
+# [*max_age*]
+# Defines number of days after which phpunit should be updated
+#
+# [*source*]
+# Holds URL to the phpunit source file
+#
+# [*path*]
+# Holds path to the phpunit executable
+#
+# === Examples
+#
+#  include php::phpunit::auto_update
+#  class { "php::phpunit::auto_update":
+#    "max_age" => 90
+#  }
+#
+# === Authors
+#
+# Christian "Jippi" Winther <jippignu@gmail.com>
+# Robin Gloster <robin.gloster@mayflower.de>
+#
+# === Copyright
+#
+# See LICENSE file
+#
+class php::phpunit::auto_update (
+  $max_age,
+  $source,
+  $path,
+) {
+
+  if $caller_module_name != $module_name {
+    warning("${name} is not part of the public API of the ${module_name} module and should not be directly included in the manifest.")
+  }
+
+  exec { 'update phpunit':
+    command => "wget ${source} -O ${path}",
+    onlyif  => "test `find '${path}' -mtime +${max_age}`",
+    path    => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
+    require => File[$path],
+  }
+}


### PR DESCRIPTION
The composer class works well enough that it can pretty much be completely reused for an easy phpunit install. 
