### PR TITLE
Fix version issues with librarian-puppet

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,11 +9,11 @@
   "issues_url": "https://github.com/Mayflower/puppet-php/issues",
   "description": "Puppet module that aims to manage PHP on every linux distribution with sane defaults and easy, hiera-friendly configuration",
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": "~ 4.2" },
-    { "name": "puppetlabs/apt", "version_requirement": "~ 1.7" },
-    { "name": "puppetlabs/inifile", "version_requirement": "~ 1.0" },
-    { "name": "darin/zypprepo", "version_requirement": "~ 1.0" },
-    { "name": "example42/yum", "version_requirement": "~ 2.1" }
+    { "name": "puppetlabs/stdlib", "version_requirement": "4.x" },
+    { "name": "puppetlabs/apt", "version_requirement": "1.x" },
+    { "name": "puppetlabs/inifile", "version_requirement": "1.x" },
+    { "name": "darin/zypprepo", "version_requirement": "1.x" },
+    { "name": "example42/yum", "version_requirement": "2.x" }
   ],
   "requirements": [
     { "name": "puppet", "version_requirement": "3.x" },


### PR DESCRIPTION
This should be compatible with both r10k and librarian-puppet. There is no matcher in librarian-puppet for the tilde though.
