### PR TITLE
Allow packaged extensions to be loaded as Zend extensions

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -39,7 +39,7 @@
 #
 # [*zend*]
 #  Boolean parameter, whether to load extension as zend_extension.
-#  This can only be set for pecl modules. Defaults to false.
+#  Defaults to false.
 #
 # [*settings*]
 #   Nested hash of global config parameters for php.ini
@@ -121,10 +121,6 @@ define php::extension(
     }
   }
 
-  if $provider != 'pecl' and $zend {
-    fail('You can only use the zend parameter for pecl PHP extensions!')
-  }
-
   if $zend == true {
     $extension_key = 'zend_extension'
     if $php_api_version != undef {
@@ -158,25 +154,10 @@ define php::extension(
     $full_settings = $settings
   }
 
-  if $provider == 'pecl' {
-    $final_settings = deep_merge(
-      {"${extension_key}" => "${module_path}${so_name}.so"},
-      $full_settings
-    )
-  }
-  else {
-    # On FreeBSD systems the settings file is required for every module
-    # (regardless of provider) to allow for proper module management.
-    if $::osfamily == 'FreeBSD' {
-      $final_settings = deep_merge(
-        {"${extension_key}" => "${name}.so"},
-        $full_settings
-      )
-    }
-    else {
-      $final_settings = $full_settings
-    }
-  }
+  $final_settings = deep_merge(
+    {"${extension_key}" => "${module_path}${so_name}.so"},
+    $full_settings
+  )
 
   $config_root_ini = pick_default($::php::config_root_ini, $::php::params::config_root_ini)
   ::php::config { $title:

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -30,7 +30,8 @@ describe 'php::extension' do
             should contain_php__config('json').with({
               :file   => "#{etcdir}/json.ini",
               :config => {
-                'test' => 'foo'
+                'extension' => 'json.so',
+                'test'      => 'foo'
               },
             })
           }
@@ -49,6 +50,7 @@ describe 'php::extension' do
           it {
             should contain_php__config('json').with({
               :config => {
+                'extension' => 'json.so',
                 'json.test' => 'foo'
               }
             })
@@ -68,26 +70,17 @@ describe 'php::extension' do
           it {
             should contain_php__config('json').with({
               :config => {
-                'bar.test' => 'foo'
+                'extension' => 'json.so',
+                'bar.test'  => 'foo'
               }
             })
           }
         end
 
-        context 'non-pecl extensions cannot be configured as zend' do
+        context 'extensions can be configured as zend' do
           let(:title) { 'xdebug' }
           let(:params) {{
             :zend => true,
-          }}
-
-          it { expect { should raise_error(Puppet::Error) }}
-        end
-
-        context 'pecl extensions can be configured as zend' do
-          let(:title) { 'xdebug' }
-          let(:params) {{
-            :provider => 'pecl',
-            :zend     => true
           }}
 
           it {


### PR DESCRIPTION
# 54 (and #52) added support for Zend extensions, but as stated only allows them for PECL installed extensions. I don't think this is the right behavior, so this PR removes that restriction and allows any extension to be designated as a Zend extension.

Take for example Xdebug, which is packaged as `php5-xdebug` on Debian. Xdebug _WANTS_ to be loaded as a Zend extension, and won't work otherwise.

This PR is pretty opinionated in that it uses `php::config` to enforce either an extension or zend_extension value to be put into the mods-available configuration. Previously these lines were only managed for PECL extensions, or on FreeBSD. I don't see a reason to not do it for all extensions. This doesn't seem to cause any issues for me, but it'd be great to get some additional thought on the implications of this change.
