### PR TITLE
Pipe was broken in the previous rubucop fix

### DIFF
--- a/lib/puppet/provider/package/pecl.rb
+++ b/lib/puppet/provider/package/pecl.rb
@@ -88,7 +88,7 @@ Puppet::Type.type(:package).provide :pecl, parent: Puppet::Provider::Package do
       end
     end
 
-    if pipe == @resource[:pipe]
+    if @resource[:pipe]
       command << '<<<'
       command << @resource[:pipe]
     end


### PR DESCRIPTION
Pipe was being set previously, 2 commits back, but then not used so rubucop complained.  1 commit back, pipe was then changed to being compared, which broke it because it was never set.  This fixes that to remove the variable `pipe` altogether since we only use @resource[:pipe] once and don't need a variable for it.  Brings it in line with things like @resource[:source]

Fixes #242 