### PR TITLE
fixtures: don't pin puppetlabs-apt version

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,7 @@
 fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    apt:
-      repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
-      branch: "1.8.x"
+    apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
     zypprepo: "git://github.com/deadpoint/puppet-zypprepo.git"
     inifile: "git://github.com/puppetlabs/puppetlabs-inifile.git"
   symlinks:


### PR DESCRIPTION
Previously this was frozen to 1.8.x, released about 18 months ago.