### PR TITLE
Fix dependency for extentions with no package source

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -88,6 +88,7 @@ define php::extension(
   }
 
   if $provider != 'none' {
+
     if $provider == 'pecl' {
       $real_package = "pecl-${title}"
     }
@@ -123,6 +124,10 @@ define php::extension(
         source   => $real_source,
       })
     }
+
+    $package_depends = "Package[${real_package}]"
+  } else {
+    $package_depends = undef
   }
 
   if $provider != 'pecl' and $zend {
@@ -186,7 +191,7 @@ define php::extension(
   ::php::config { $title:
     file    => "${config_root_ini}/${lowercase_title}.ini",
     config  => $final_settings,
-    require => Package[$real_package],
+    require => $package_depends,
   }
 
   # Ubuntu/Debian systems use the mods-available folder. We need to enable

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -43,6 +43,28 @@ describe 'php::extension' do
           end
         end
 
+        context 'configure extension without installing a package' do
+          let(:title) { 'json' }
+          let(:params) do
+            {
+              provider: 'none',
+              settings: {
+                'test' => 'foo'
+              }
+            }
+          end
+
+          it do
+            is_expected.to contain_php__config('json').with(
+              file: "#{etcdir}/json.ini",
+              require: nil,
+              config: {
+                'test' => 'foo'
+              }
+            )
+          end
+        end
+
         context 'add settings prefix if requested' do
           let(:title) { 'json' }
           let(:params) do


### PR DESCRIPTION
This fixes an issue where setting `source => 'none'` to a `php::extension` resource results in the following error:
```
Error: Could not find dependency Package[undef] for Php::Config[json] at /etc/puppet/modules/php/manifests/extension.pp:190
``` 