### PR TITLE
Update module Ubuntu 14.04 default to official repository setup

### DIFF
--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -26,7 +26,8 @@ class php::dev(
     default   => $package,
   }
 
-  if $::operatingsystem == 'Ubuntu' {
+  # Default PHP come with xml module and no seperate package for it
+  if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease >= '16.04'  {
     ensure_packages(["${php::package_prefix}xml"], {
       ensure  => present,
       require => Class['::apt::update'],

--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -27,7 +27,7 @@ class php::dev(
   }
 
   # Default PHP come with xml module and no seperate package for it
-  if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease >= '16.04'  {
+  if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0  {
     ensure_packages(["${php::package_prefix}xml"], {
       ensure  => present,
       require => Class['::apt::update'],

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -31,7 +31,7 @@ class php::globals (
     'Debian' => $::operatingsystem ? {
       'Ubuntu' => $::operatingsystemrelease ? {
         /^(16.04)$/ => '7.0',
-        default => '5.6',
+        default => '5.x',
       },
       default => '5.x',
     },
@@ -53,41 +53,25 @@ class php::globals (
             $ext_tool_query       = '/usr/sbin/php5query'
             $package_prefix       = 'php5-'
           }
-          /^5\.5/: {
+          /^[57].[0-9]/: {
             $default_config_root  = "/etc/php/${globals_php_version}"
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
             $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
             $fpm_service_name     = "php${globals_php_version}-fpm"
             $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
             $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix       = 'php5.5-'
-          }
-          /^5\.6/: {
-            $default_config_root  = "/etc/php/${globals_php_version}"
-            $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name     = "php${globals_php_version}-fpm"
-            $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
-            $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix       = 'php5.6-'
-          }
-          /^7/: {
-            $default_config_root  = "/etc/php/${globals_php_version}"
-            $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name     = "php${globals_php_version}-fpm"
-            $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
-            $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix       = 'php7.0-'
+            $package_prefix       = "php${globals_php_version}-"
           }
           default: {
-            $default_config_root  = "/etc/php/${globals_php_version}"
-            $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name     = "php${globals_php_version}-fpm"
-            $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
-            $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix       = 'php-'
+            # Default php installation from Ubuntu official repository use the following paths until 16.04
+            # For PPA please use the $php_version to override it.
+            $default_config_root  = '/etc/php5'
+            $default_fpm_pid_file = '/var/run/php5-fpm.pid'
+            $fpm_error_log        = '/var/log/php5-fpm.log'
+            $fpm_service_name     = 'php5-fpm'
+            $ext_tool_enable      = '/usr/sbin/php5enmod'
+            $ext_tool_query       = '/usr/sbin/php5query'
+            $package_prefix       = 'php5-'
           }
         }
       } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,7 +47,7 @@ class php::params inherits php::globals {
         }
 
         'Ubuntu': {
-          $manage_repos = true
+          $manage_repos = false
         }
 
         default: {

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -43,7 +43,8 @@ class php::pear (
   validate_string($ensure)
   validate_string($package_name)
 
-  if $::operatingsystem == 'Ubuntu' {
+  # Default PHP come with xml module and no seperate package for it
+  if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease >= '16.04' {
     ensure_packages(["${php::package_prefix}xml"], {
       ensure  => present,
       require => Class['::apt::update'],

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -44,7 +44,7 @@ class php::pear (
   validate_string($package_name)
 
   # Default PHP come with xml module and no seperate package for it
-  if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease >= '16.04' {
+  if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0 {
     ensure_packages(["${php::package_prefix}xml"], {
       ensure  => present,
       require => Class['::apt::update'],

--- a/metadata.json
+++ b/metadata.json
@@ -22,9 +22,7 @@
   "operatingsystem_support": [
     { "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.10",
-        "14.04",
-        "12.04"
+        "14.04"
       ]
     },
     { "operatingsystem": "Debian",

--- a/spec/classes/php_fpm_config_spec.rb
+++ b/spec/classes/php_fpm_config_spec.rb
@@ -7,64 +7,32 @@ describe 'php::fpm::config' do
         facts
       end
 
-      case facts[:operatingsystem]
-      when 'Ubuntu'
-        describe 'creates config file' do
-          let(:params) do
-            {
-              inifile: '/etc/php/5.6/conf.d/unique-name.ini',
+      describe 'creates config file' do
+        let(:params) do
+          {
+              inifile: '/etc/php5/conf.d/unique-name.ini',
               settings: {
-                'apc.enabled' => 1
+                  'apc.enabled' => 1
               }
-            }
-          end
-
-          it do
-            is_expected.to contain_class('php::fpm::config').with(
-              inifile: '/etc/php/5.6/conf.d/unique-name.ini',
-              settings: {
-                'apc.enabled' => 1
-              }
-            )
-          end
-
-          it do
-            is_expected.to contain_php__config('fpm').with(
-              file: '/etc/php/5.6/conf.d/unique-name.ini',
-              config: {
-                'apc.enabled' => 1
-              }
-            )
-          end
+          }
         end
-      else
-        describe 'creates config file' do
-          let(:params) do
-            {
+
+        it do
+          is_expected.to contain_class('php::fpm::config').with(
               inifile: '/etc/php5/conf.d/unique-name.ini',
               settings: {
-                'apc.enabled' => 1
+                  'apc.enabled' => 1
               }
-            }
-          end
+          )
+        end
 
-          it do
-            is_expected.to contain_class('php::fpm::config').with(
-              inifile: '/etc/php5/conf.d/unique-name.ini',
-              settings: {
-                'apc.enabled' => 1
-              }
-            )
-          end
-
-          it do
-            is_expected.to contain_php__config('fpm').with(
+        it do
+          is_expected.to contain_php__config('fpm').with(
               file: '/etc/php5/conf.d/unique-name.ini',
               config: {
-                'apc.enabled' => 1
+                  'apc.enabled' => 1
               }
-            )
-          end
+          )
         end
       end
     end

--- a/spec/classes/php_fpm_spec.rb
+++ b/spec/classes/php_fpm_spec.rb
@@ -9,7 +9,12 @@ describe 'php::fpm', type: :class do
       describe 'when called with no parameters' do
         case facts[:osfamily]
         when 'Debian'
-          let(:params) { { package: 'php5-fpm', ensure: 'latest' } }
+          let(:params) do
+            {
+                package: 'php5-fpm',
+                ensure: 'latest'
+            }
+          end
           it { is_expected.to contain_package('php5-fpm').with_ensure('latest') }
           it { is_expected.to contain_service('php5-fpm').with_ensure('running') }
         else

--- a/spec/classes/php_fpm_spec.rb
+++ b/spec/classes/php_fpm_spec.rb
@@ -9,16 +9,9 @@ describe 'php::fpm', type: :class do
       describe 'when called with no parameters' do
         case facts[:osfamily]
         when 'Debian'
-          case facts[:operatingsystem]
-          when 'Ubuntu'
-            let(:params) { { package: 'php5.6-fpm', ensure: 'latest' } }
-            it { is_expected.to contain_package('php5.6-fpm').with_ensure('latest') }
-            it { is_expected.to contain_service('php5.6-fpm').with_ensure('running') }
-          when 'Debian'
-            let(:params) { { package: 'php5-fpm', ensure: 'latest' } }
-            it { is_expected.to contain_package('php5-fpm').with_ensure('latest') }
-            it { is_expected.to contain_service('php5-fpm').with_ensure('running') }
-          end
+          let(:params) { { package: 'php5-fpm', ensure: 'latest' } }
+          it { is_expected.to contain_package('php5-fpm').with_ensure('latest') }
+          it { is_expected.to contain_service('php5-fpm').with_ensure('running') }
         else
           it { is_expected.to contain_service('php-fpm').with_ensure('running') }
         end

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -32,26 +32,13 @@ describe 'php', type: :class do
         let(:params) { { package_prefix: 'myphp-' } }
         case facts[:osfamily]
         when 'Debian'
-          case facts[:operatingsystem]
-          when 'Ubuntu'
-            it { is_expected.to contain_class('php::fpm') }
-            it { is_expected.to contain_package('myphp-cli').with_ensure('present') }
-            it { is_expected.to contain_package('myphp-fpm').with_ensure('present') }
-            it { is_expected.to contain_class('php::dev') }
-            it { is_expected.to contain_package('myphp-dev').with_ensure('present') }
-            # The -xml package is enforced via the dev class
-            it { is_expected.to contain_package('myphp-xml').with_ensure('present') }
-            it { is_expected.to contain_package('php-pear').with_ensure('present') }
-            it { is_expected.to contain_class('php::composer') }
-          when 'Debian'
-            it { is_expected.not_to contain_class('php::global') }
-            it { is_expected.to contain_class('php::fpm') }
-            it { is_expected.to contain_package('myphp-cli').with_ensure('present') }
-            it { is_expected.to contain_package('myphp-fpm').with_ensure('present') }
-            it { is_expected.to contain_package('myphp-dev').with_ensure('present') }
-            it { is_expected.to contain_package('php-pear').with_ensure('present') }
-            it { is_expected.to contain_class('php::composer') }
-          end
+          it { is_expected.not_to contain_class('php::global') }
+          it { is_expected.to contain_class('php::fpm') }
+          it { is_expected.to contain_package('myphp-cli').with_ensure('present') }
+          it { is_expected.to contain_package('myphp-fpm').with_ensure('present') }
+          it { is_expected.to contain_package('myphp-dev').with_ensure('present') }
+          it { is_expected.to contain_package('php-pear').with_ensure('present') }
+          it { is_expected.to contain_class('php::composer') }
         when 'Suse'
           it { is_expected.to contain_class('php::global') }
           it { is_expected.to contain_package('php5').with_ensure('present') }

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -10,26 +10,13 @@ describe 'php', type: :class do
       describe 'when called with no parameters' do
         case facts[:osfamily]
         when 'Debian'
-          case facts[:operatingsystem]
-          when 'Ubuntu'
-            it { is_expected.to contain_class('php::fpm') }
-            it { is_expected.to contain_package('php5.6-cli').with_ensure('present') }
-            it { is_expected.to contain_package('php5.6-fpm').with_ensure('present') }
-            it { is_expected.to contain_class('php::dev') }
-            it { is_expected.to contain_package('php5.6-dev').with_ensure('present') }
-            # The -xml package is enforced via the dev class
-            it { is_expected.to contain_package('php5.6-xml').with_ensure('present') }
-            it { is_expected.to contain_package('php-pear').with_ensure('present') }
-            it { is_expected.to contain_class('php::composer') }
-          when 'Debian'
-            it { is_expected.not_to contain_class('php::global') }
-            it { is_expected.to contain_class('php::fpm') }
-            it { is_expected.to contain_package('php5-cli').with_ensure('present') }
-            it { is_expected.to contain_package('php5-fpm').with_ensure('present') }
-            it { is_expected.to contain_package('php5-dev').with_ensure('present') }
-            it { is_expected.to contain_package('php-pear').with_ensure('present') }
-            it { is_expected.to contain_class('php::composer') }
-          end
+          it { is_expected.not_to contain_class('php::global') }
+          it { is_expected.to contain_class('php::fpm') }
+          it { is_expected.to contain_package('php5-cli').with_ensure('present') }
+          it { is_expected.to contain_package('php5-fpm').with_ensure('present') }
+          it { is_expected.to contain_package('php5-dev').with_ensure('present') }
+          it { is_expected.to contain_package('php-pear').with_ensure('present') }
+          it { is_expected.to contain_class('php::composer') }
         when 'Suse'
           it { is_expected.to contain_class('php::global') }
           it { is_expected.to contain_package('php5').with_ensure('present') }

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -6,17 +6,15 @@ describe 'php::extension' do
       let :facts do
         facts
       end
-      let(:pre_condition) { 'include php::params' }
+      let(:pre_condition) { '
+        include php
+        include php::params
+      ' }
 
       unless facts[:osfamily] == 'Suse' || facts[:osfamily] == 'FreeBSD' # FIXME: something is wrong on these
         etcdir = case facts[:osfamily]
                  when 'Debian'
-                   case facts[:operatingsystem]
-                   when 'Ubuntu'
-                     '/etc/php/5.6/mods-available'
-                   else
-                     '/etc/php5/mods-available'
-                   end
+                   '/etc/php5/mods-available'
                  else
                    '/etc/php.d'
                  end

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -6,10 +6,10 @@ describe 'php::extension' do
       let :facts do
         facts
       end
-      let(:pre_condition) { '
-        include php
-        include php::params
-      ' }
+      
+      let(:pre_condition) do
+        'include php::params'
+      end
 
       unless facts[:osfamily] == 'Suse' || facts[:osfamily] == 'FreeBSD' # FIXME: something is wrong on these
         etcdir = case facts[:osfamily]

--- a/spec/defines/fpm_pool_spec.rb
+++ b/spec/defines/fpm_pool_spec.rb
@@ -14,7 +14,7 @@ describe 'php::fpm::pool' do
             let(:title) { 'unique-name' }
             let(:params) { {} }
 
-            it { is_expected.to contain_file('/etc/php/5.6/fpm/pool.d/unique-name.conf') }
+            it { is_expected.to contain_file('/etc/php5/fpm/pool.d/unique-name.conf') }
           end
         when 'Debian'
           context 'plain config' do


### PR DESCRIPTION
Fix for Ubuntu 14.04 Php installation:

Summary:
* The currents rule only work for PPA. Using 14.04 Official Ubuntu repository does not match any of the rules. 
* Removed 14.10 from metadata. It is in EOL and thing can randomly break. 
* Removed 12.04 from metadata. Default installation is 5.3, this module won't support any of it