### PR TITLE
fix php5enmod / php5query for Ubuntu Trusty and php5.5

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -44,7 +44,7 @@ class php::globals (
     'Debian': {
       if $::operatingsystem == 'Ubuntu' {
         case $globals_php_version {
-          /^5\.4/: {
+          /^5\.[45]/: {
             $default_config_root  = '/etc/php5'
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
             $fpm_error_log        = '/var/log/php5-fpm.log'


### PR DESCRIPTION
on trusty with base php 5.5, the php5enmod and php5query commands are:
'/usr/sbin/php5enmod'
'/usr/sbin/php5query'

so I think it's the best to use the same case as for php 5.4 - not sure if php 5.4 is even supported / used though any longer on Trusty. 
