### PR TITLE
Allow packaged extensions to be loaded as Zend extensions (bis)

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -39,7 +39,7 @@
 #
 # [*zend*]
 #  Boolean parameter, whether to load extension as zend_extension.
-#  This can only be set for pecl modules. Defaults to false.
+#  Defaults to false.
 #
 # [*settings*]
 #   Nested hash of global config parameters for php.ini
@@ -130,10 +130,6 @@ define php::extension(
     $package_depends = undef
   }
 
-  if $provider != 'pecl' and $zend {
-    fail('You can only use the zend parameter for pecl PHP extensions!')
-  }
-
   if $zend == true {
     $extension_key = 'zend_extension'
     if $php_api_version != undef {
@@ -167,25 +163,10 @@ define php::extension(
     $full_settings = $settings
   }
 
-  if $provider == 'pecl' {
-    $final_settings = deep_merge(
-      {"${extension_key}" => "${module_path}${so_name}.so"},
-      $full_settings
-    )
-  }
-  else {
-    # On FreeBSD systems the settings file is required for every module
-    # (regardless of provider) to allow for proper module management.
-    if $::osfamily == 'FreeBSD' {
-      $final_settings = deep_merge(
-        {"${extension_key}" => "${name}.so"},
-        $full_settings
-      )
-    }
-    else {
-      $final_settings = $full_settings
-    }
-  }
+  $final_settings = deep_merge(
+    {"${extension_key}" => "${module_path}${so_name}.so"},
+    $full_settings
+  )
 
   $config_root_ini = pick_default($::php::config_root_ini, $::php::params::config_root_ini)
   ::php::config { $title:

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -77,7 +77,14 @@ describe 'php::extension' do
             }
           end
 
-          it { is_expected.to contain_php__config('json').with_config('json.test' => 'foo') }
+          it do
+            is_expected.to contain_php__config('json').with(
+              config: {
+                'extension' => 'json.so',
+                'json.test' => 'foo'
+              }
+            )
+          end
         end
 
         context 'use specific settings prefix if requested' do
@@ -87,13 +94,19 @@ describe 'php::extension' do
               name: 'json',
               settings_prefix: 'bar',
               settings: {
-                'extension' => 'json.so',
-                'test'      => 'foo'
+                'test' => 'foo'
               }
             }
           end
 
-          it { is_expected.to contain_php__config('json').with_config('bar.test' => 'foo') }
+          it do
+            is_expected.to contain_php__config('json').with(
+              config: {
+                'extension' => 'json.so',
+                'bar.test'  => 'foo',
+              }
+            )
+          end
         end
 
         context 'extensions can be configured as zend' do

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -6,7 +6,7 @@ describe 'php::extension' do
       let :facts do
         facts
       end
-      
+
       let(:pre_condition) do
         'include php::params'
       end
@@ -35,7 +35,8 @@ describe 'php::extension' do
             is_expected.to contain_php__config('json').with(
               file: "#{etcdir}/json.ini",
               config: {
-                'test' => 'foo'
+                'extension' => 'json.so',
+                'test'      => 'foo'
               }
             )
           end
@@ -57,7 +58,8 @@ describe 'php::extension' do
               file: "#{etcdir}/json.ini",
               require: nil,
               config: {
-                'test' => 'foo'
+                'extension' => 'json.so',
+                'test'      => 'foo'
               }
             )
           end
@@ -85,7 +87,8 @@ describe 'php::extension' do
               name: 'json',
               settings_prefix: 'bar',
               settings: {
-                'test' => 'foo'
+                'extension' => 'json.so',
+                'test'      => 'foo'
               }
             }
           end
@@ -93,22 +96,10 @@ describe 'php::extension' do
           it { is_expected.to contain_php__config('json').with_config('bar.test' => 'foo') }
         end
 
-        context 'non-pecl extensions cannot be configured as zend' do
+        context 'extensions can be configured as zend' do
           let(:title) { 'xdebug' }
           let(:params) do
             {
-              zend: true
-            }
-          end
-
-          it { expect { is_expected.to raise_error(Puppet::Error) } }
-        end
-
-        context 'pecl extensions can be configured as zend' do
-          let(:title) { 'xdebug' }
-          let(:params) do
-            {
-              provider: 'pecl',
               zend: true
             }
           end


### PR DESCRIPTION
Thanks to [chrisboulton](https://github.com/chrisboulton), see https://github.com/voxpupuli/puppet-php/pull/193

https://github.com/voxpupuli/puppet-php/pull/54 (and https://github.com/voxpupuli/puppet-php/issues/52) added support for Zend extensions, but as stated only allows them for PECL installed extensions. I don't think this is the right behavior, so this PR removes that restriction and allows any extension to be designated as a Zend extension.

Take for example Xdebug, which is packaged as php5-xdebug on Debian. Xdebug WANTS to be loaded as a Zend extension, and won't work otherwise.

This PR is pretty opinionated in that it uses php::config to enforce either an extension or zend_extension value to be put into the mods-available configuration. Previously these lines were only managed for PECL extensions, or on FreeBSD. I don't see a reason to not do it for all extensions. This doesn't seem to cause any issues for me, but it'd be great to get some additional thought on the implications of this change.
