### PR TITLE
Support using an http proxy for downloading composer

### DIFF
--- a/manifests/composer/auto_update.pp
+++ b/manifests/composer/auto_update.pp
@@ -11,6 +11,9 @@
 # [*path*]
 #   Holds path to the Composer executable
 #
+# [*environment*]
+#   Environment variables for settings such as http_proxy, https_proxy, or ftp_proxy
+#
 # === Examples
 #
 #  include php::composer::auto_update
@@ -22,6 +25,7 @@ class php::composer::auto_update (
   $max_age,
   $source,
   $path,
+  $environment = undef,
 ) {
 
   if $caller_module_name != $module_name {
@@ -29,9 +33,10 @@ class php::composer::auto_update (
   }
 
   exec { 'update composer':
-    command => "wget ${source} -O ${path}",
-    onlyif  => "test `find '${path}' -mtime +${max_age}`",
-    path    => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/', '/usr/local/bin', '/usr/local/sbin' ],
-    require => File[$path],
+    command     => "curl -L ${source} -o ${path}",
+    environment => $environment,
+    onlyif      => "test `find '${path}' -mtime +${max_age}`",
+    path        => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/', '/usr/local/bin', '/usr/local/sbin' ],
+    require     => File[$path],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,11 @@
 # [*phpunit*]
 #   Install phpunit
 #
+# [*environment*]
+#   Environment variables for settings such as http_proxy, https_proxy, or ftp_proxy.
+#   These are passed through to the underlying exec(s), so it follows the same format
+#   of the exec type `environment`
+#
 # [*extensions*]
 #   Install PHP extensions, this is overwritten by hiera hash `php::extensions`
 #
@@ -93,6 +98,7 @@ class php (
   $pear                 = true,
   $pear_ensure          = $::php::params::pear_ensure,
   $phpunit              = false,
+  $environment          = undef,
   $extensions           = {},
   $settings             = {},
   $package_prefix       = $::php::params::package_prefix,
@@ -188,7 +194,9 @@ class php (
   }
   if $composer {
     Anchor['php::begin'] ->
-      class { '::php::composer': } ->
+      class { '::php::composer':
+        environment => $environment,
+      } ->
     Anchor['php::end']
   }
   if $pear {


### PR DESCRIPTION
We need to download composer through a web proxy.
wget is broken when it comes to downloading through a proxy and using https, so we also need to switch to curl to achieve this.

Maybe we should eventually switch to the archive module for this? In any case this seems to work well for now.