### PR TITLE
Manage apache/PHP configurations

### DIFF
--- a/manifests/apache_config.pp
+++ b/manifests/apache_config.pp
@@ -1,0 +1,29 @@
+# Install and configure php apache settings
+#
+# === Parameters
+#
+# [*inifile*]
+#   The path to the ini php-apache ini file
+#
+# [*settings*]
+#   Hash with nested hash of key => value to set in inifile
+#
+class php::apache_config(
+  $inifile  = $::php::params::apache_inifile,
+  $settings = {}
+) inherits ::php::params {
+
+  if $caller_module_name != $module_name {
+    warning('php::apache_config is private')
+  }
+
+  validate_absolute_path($inifile)
+  validate_hash($settings)
+
+  $real_settings = deep_merge($settings, hiera_hash('php::apache::settings', {}))
+
+  ::php::config { 'apache':
+    file   => $inifile,
+    config => $real_settings,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,9 @@
 # [*phpunit*]
 #   Install phpunit
 #
+# [*apache_config*]
+#   Manage apache's mod_php configuration
+#
 # [*environment*]
 #   Environment variables for settings such as http_proxy, https_proxy, or ftp_proxy.
 #   These are passed through to the underlying exec(s), so it follows the same format
@@ -119,6 +122,7 @@ class php (
   $pear                     = true,
   $pear_ensure              = $::php::params::pear_ensure,
   $phpunit                  = false,
+  $apache_config            = false,
   $environment              = undef,
   $manage_curl              = true,
   $extensions               = {},
@@ -142,6 +146,7 @@ class php (
   validate_bool($ext_tool_enabled)
   validate_string($pear_ensure)
   validate_bool($phpunit)
+  validate_bool($apache_config)
   validate_bool($manage_curl)
   validate_hash($extensions)
   validate_hash($settings)
@@ -231,6 +236,13 @@ class php (
   if $phpunit {
     Anchor['php::begin'] ->
       class { '::php::phpunit': } ->
+    Anchor['php::end']
+  }
+  if $apache_config {
+    Anchor['php::begin'] ->
+      class { '::php::apache_config':
+        settings => $real_settings,
+      } ->
     Anchor['php::end']
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,6 +32,7 @@ class php::params inherits php::globals {
       $fpm_service_name        = $php::globals::fpm_service_name
       $fpm_user                = 'www-data'
       $fpm_group               = 'www-data'
+      $apache_inifile          = "${config_root}/apache2/php.ini"
       $embedded_package_suffix = 'embed'
       $embedded_inifile        = "${config_root}/embed/php.ini"
       $package_prefix          = $php::globals::package_prefix
@@ -115,6 +116,7 @@ class php::params inherits php::globals {
       $fpm_service_name        = 'php-fpm'
       $fpm_user                = 'apache'
       $fpm_group               = 'apache'
+      $apache_inifile          = '/etc/php.ini'
       $embedded_package_suffix = 'embedded'
       $embedded_inifile        = '/etc/php.ini'
       $package_prefix          = 'php-'


### PR DESCRIPTION
I'd like to be able to manage the php.ini file (and extensions) used by apache/mod_php since I have some applications that can't be easily converted to using php-fpm.

This lacks configuration parameters for Suse and BSD, but I'm hoping that someone will be able to chime in and I'll add them.