### PR TITLE
use voxpupuli/archive to download composer

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,6 @@ fixtures:
     apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
     zypprepo: "git://github.com/deadpoint/puppet-zypprepo.git"
     inifile: "git://github.com/puppetlabs/puppetlabs-inifile.git"
+    archive: "git://github.com/voxpupuli/puppet-archive.git"
   symlinks:
     php: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,13 +57,11 @@
 # [*apache_config*]
 #   Manage apache's mod_php configuration
 #
-# [*environment*]
-#   Environment variables for settings such as http_proxy, https_proxy, or ftp_proxy.
-#   These are passed through to the underlying exec(s), so it follows the same format
-#   of the exec type `environment`
+# [*proxy_type*]
+#    proxy server type (none|http|https|ftp)
 #
-# [*manage_curl*]
-#   Should we ensure curl is installed or do you want to manage that?
+# [*proxy_server*]
+#   specify a proxy server, with port number if needed. ie: https://example.com:8080.
 #
 # [*extensions*]
 #   Install PHP extensions, this is overwritten by hiera hash `php::extensions`
@@ -123,8 +121,8 @@ class php (
   $pear_ensure              = $::php::params::pear_ensure,
   $phpunit                  = false,
   $apache_config            = false,
-  $environment              = undef,
-  $manage_curl              = true,
+  $proxy_type               = undef,
+  $proxy_server             = undef,
   $extensions               = {},
   $settings                 = {},
   $package_prefix           = $::php::params::package_prefix,
@@ -147,7 +145,6 @@ class php (
   validate_string($pear_ensure)
   validate_bool($phpunit)
   validate_bool($apache_config)
-  validate_bool($manage_curl)
   validate_hash($extensions)
   validate_hash($settings)
   validate_hash($fpm_pools)
@@ -221,8 +218,8 @@ class php (
   if $composer {
     Anchor['php::begin'] ->
       class { '::php::composer':
-        environment => $environment,
-        manage_curl => $manage_curl,
+        proxy_type   => $proxy_type,
+        proxy_server => $proxy_server,
       } ->
     Anchor['php::end']
   }

--- a/metadata.json
+++ b/metadata.json
@@ -13,6 +13,7 @@
     { "name": "puppetlabs/apt", "version_requirement": ">= 1.8.0 < 3.0.0" },
     { "name": "puppetlabs/inifile", "version_requirement": "1.x" },
     { "name": "darin/zypprepo", "version_requirement": "1.x" },
+    { "name": "puppet/archive", "version_requirement": "1.x" },
     { "name": "example42/yum", "version_requirement": "2.x" }
   ],
   "requirements": [


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

rather than using a hand-crafted curl call, we use voxpupuli/archive to
download composer. This has the benefit that it doesn't require us to
$manage_curl. But we also remove `$environment`! This variable name is
poorly chosen. Overriding it (or even just setting it to `undef`), could
mean that someone's `hiera()` lookups are failing, as soon as they enter
our module!

This pull-request addresses #273.