### PR TITLE
respect $manage_repos, do not include ::apt if set to false

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -14,6 +14,7 @@
 #
 class php::packages (
   $ensure          = $::php::ensure,
+  $manage_repos    = $::php::manage_repos,
   $names_to_prefix = prefix(
     $::php::params::common_package_suffixes, $::php::package_prefix # lint:ignore:parameter_documentation
   ),
@@ -30,7 +31,9 @@ class php::packages (
 
   $real_names = union($names, $names_to_prefix)
   if $::osfamily == 'debian' {
-    include ::apt
+    if $manage_repos {
+      include ::apt
+    }
     package { $real_names:
       ensure  => $ensure,
       require => Class['::apt::update'],


### PR DESCRIPTION
PR #250 introduced code that unconditionally includes `::apt`. This should be changed to respect wether `$manage_repos` is actually set to `true` or not.

Otherwise I'm unable to use my own repo management, because the include leads to a duplicate declaration:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Class[Apt] is already declared
```

