### PR TITLE
Add PHP 7.1 support on Debian

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -66,7 +66,7 @@ class php::globals (
         }
       } else {
         case $globals_php_version {
-          /^7/: {
+          /^7\.[0-9]/: {
             $default_config_root  = "/etc/php/${globals_php_version}"
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
             $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -69,4 +69,26 @@ class php::repo::debian(
       }
     }
   }
+
+  if ($php::globals::php_version == '7.1') {
+    # Required packages for PHP 7.1 repository
+    ensure_packages(['lsb-release', 'ca-certificates'], {'ensure' => 'present'})
+
+    # Add PHP 7.1 key + repository
+    apt::key { 'php::repo::debian-php71':
+      key        => 'DF3D585DB8F0EB658690A554AC0E47584A7A714D',
+      key_source => 'https://packages.sury.org/php/apt.gpg',
+    }
+
+    ::apt::source { 'source_php_71':
+      location    => 'https://packages.sury.org/php/',
+      release     => $::lsbdistcodename,
+      repos       => 'main',
+      include_src => false,
+      require     => [
+        Apt::Key['php::repo::debian-php71'],
+        Package['apt-transport-https', 'lsb-release', 'ca-certificates']
+      ],
+    }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 4.1.0 < 5.0.0"
+      "version_requirement": ">= 4.4.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/inifile",

--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.16.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/apt",

--- a/spec/classes/php_repo_spec.rb
+++ b/spec/classes/php_repo_spec.rb
@@ -7,6 +7,10 @@ describe 'php::repo', type: :class do
         facts
       end
 
+      let :pre_condition do
+        'include php'
+      end
+
       describe 'when configuring a package repo' do
         case facts[:osfamily]
         when 'Debian'


### PR DESCRIPTION
I've added support for PHP 7.1 on Debian (jessie, stretch).

```
PHP 7.1.0-5+0~20161222133327.13+jessie~1.gbp46a191 (cli) ( NTS )
Copyright (c) 1997-2016 The PHP Group
Zend Engine v3.1.0-dev, Copyright (c) 1998-2016 Zend Technologies
    with Zend OPcache v7.1.0-5+0~20161222133327.13+jessie~1.gbp46a191, Copyright (c) 1999-2016, by Zend Technologies
    with Xdebug v2.5.0, Copyright (c) 2002-2016, by Derick Rethans
```

I'm not sure if it's the most elegant way to install the required packages and how to avoid name conflicts.

Feedback is welcome.