### PR TITLE
fix pecl/pear providers query method

### DIFF
--- a/lib/puppet/provider/package/pear.rb
+++ b/lib/puppet/provider/package/pear.rb
@@ -1,112 +1,105 @@
 require 'puppet/provider/package'
 
-# PHP PEAR support.
 Puppet::Type.type(:package).provide :pear, parent: Puppet::Provider::Package do
-  desc 'PHP PEAR support. By default uses the installed channels, but you can specify the path to a pear package via ``source``.'
+  desc 'Package management via `pear`.'
 
   has_feature :versionable
   has_feature :upgradeable
   has_feature :install_options
 
-  case Facter.value(:operatingsystem)
-  when 'Solaris'
-    commands pearcmd: '/opt/coolstack/php5/bin/pear'
-  else
-    commands pearcmd: 'pear'
-  end
+  commands pear: 'pear'
 
-  def self.pearlist(hash)
-    command = [command(:pearcmd), 'list', '-a']
-    channel = 'pear'
+  ENV['TERM'] = 'dumb' # remove colors
 
-    begin
-      list = execute(command).split("\n")
-      list = list.map do |set|
-        %r{INSTALLED PACKAGES, CHANNEL (.*):}i.match(set) { |m| channel = m[1].downcase }
+  def self.pearlist(only = nil)
+    channel = nil
 
-        if hash[:justme] && set =~ %r{^#{hash[:justme]}}
-          pearhash = pearsplit(set, channel)
-          pearhash[:provider] = :pear
-          pearhash
-        elsif (pearhash = pearsplit(set, channel))
-          pearhash[:provider] = :pear
-          pearhash
-        end
-      end.compact
+    packages = pear('list', '-a').split("\n").map do |line|
+      # current channel
+      %r{INSTALLED PACKAGES, CHANNEL (.*):}i.match(line) { |m| channel = m[1].downcase }
 
-    rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, format('Could not list pears: %s', detail)
+      # parse one package
+      pearsplit(line, channel)
+    end.compact
+
+    return packages unless only
+
+    packages.find do |pkg|
+      pkg[:name].casecmp(only[:name].downcase).zero?
     end
-
-    return list.shift if hash[:justme]
-    list
   end
 
   def self.pearsplit(desc, channel)
     desc.strip!
 
     case desc
-    when %r{^$} then return nil
-    when %r{^INSTALLED}i then return nil
-    when %r{no packages installed}i then return nil
-    when %r{^=} then return nil
-    when %r{^PACKAGE}i then return nil
+    when '' then nil
+    when %r{^installed}i then nil
+    when %r{no packages installed}i then nil
+    when %r{^=} then nil
+    when %r{^package}i then nil
     when %r{^(\S+)\s+(\S+)\s+(\S+)\s*$} then
       name = Regexp.last_match(1)
       version = Regexp.last_match(2)
       state = Regexp.last_match(3)
-      return {
-        name: "#{channel}/#{name}",
-        ensure: state == 'stable' ? version : state
+
+      {
+        name: name,
+        vendor: channel,
+        ensure: state == 'stable' ? version : state,
+        provider: self.name
       }
     else
-      Puppet.debug format("Could not match '%s'", desc)
+      Puppet.warning format('Could not match %s', desc)
       nil
     end
   end
 
   def self.instances
-    pearlist(local: true).map do |hash|
+    pearlist.map do |hash|
       new(hash)
     end
   end
 
   def install(useversion = true)
     command = ['-D', 'auto_discover=1', 'upgrade']
-    command << if @resource[:install_options]
-                 @resource[:install_options]
-               else
-                 '--alldeps'
-               end
 
-    command << if @resource[:source]
-                 @resource[:source]
-               elsif (!@resource.should(:ensure).is_a? Symbol) && useversion
-                 "#{@resource[:name]}-#{@resource.should(:ensure)}"
-               else
-                 @resource[:name]
-               end
+    if @resource[:install_options]
+      command += join_options(@resource[:install_options])
+    else
+      command << '--alldeps'
+    end
 
-    pearcmd(*command)
+    pear_pkg = @resource[:source] || @resource[:name]
+    if !@resource[:ensure].is_a?(Symbol) && useversion
+      command << '-f'
+      pear_pkg << "-#{@resource[:ensure]}"
+    end
+    command << pear_pkg
+
+    if @resource[:responsefile]
+      Puppet::Util::Execution.execute(
+        [command(:pear)] + command,
+        stdinfile: @resource[:responsefile]
+      )
+    else
+      pear(*command)
+    end
   end
 
   def latest
-    # This always gets the latest version available.
-    version = ''
-    command = [command(:pearcmd), 'remote-info', @resource[:name]]
-    execute(command).each_line do |set|
-      version = set.split[1] if set =~ %r{^Latest}
-    end
-
-    version
+    target = @resource[:source] || @resource[:name]
+    pear('remote-info', target).lines.find do |set|
+      set =~ %r{^Latest}
+    end.split[1]
   end
 
   def query
-    self.class.pearlist(justme: @resource[:name])
+    self.class.pearlist(@resource)
   end
 
   def uninstall
-    output = pearcmd 'uninstall', @resource[:name]
+    output = pear 'uninstall', @resource[:name]
     raise Puppet::Error, output unless output =~ %r{^uninstall ok}
   end
 

--- a/lib/puppet/provider/package/pecl.rb
+++ b/lib/puppet/provider/package/pecl.rb
@@ -1,113 +1,36 @@
 require 'puppet/provider/package'
 
-Puppet::Type.type(:package).newparam(:pipe)
-Puppet::Type.type(:package).provide :pecl, parent: Puppet::Provider::Package do
-  desc 'PHP pecl support. By default uses the installed channels, but you can specify the path to a pecl package via ``source``.'
+Puppet::Type.type(:package).provide :pecl, parent: :pear do
+  desc 'Package management via `pecl`.'
 
   has_feature :versionable
   has_feature :upgradeable
-
-  case Facter.value(:operatingsystem)
-  when 'Solaris'
-    commands peclcmd: '/opt/coolstack/php5/bin/pecl'
-  else
-    commands peclcmd: 'pecl'
-  end
-
-  def self.pecllist(hash)
-    command = [command(:peclcmd), 'list']
-
-    begin
-      list = execute(command).split("\n").map do |set|
-        if hash[:justme] && %r{^#{hash[:justme]}$}i =~ set && (peclhash = peclsplit(set))
-          peclhash[:provider] = :peclcmd
-          peclhash
-        elsif (peclhash = peclsplit(set))
-          peclhash[:provider] = :peclcmd
-          peclhash
-        end
-      end.compact
-    rescue Puppet::ExecutionFailure => detail
-      raise Puppet::Error, format('Could not list pecls: %s', detail)
-    end
-
-    return list.shift if hash[:justme]
-    list
-  end
-
-  def self.peclsplit(desc)
-    desc.strip!
-
-    case desc
-    when %r{^INSTALLED} then return nil
-    when %r{No packages installed from channel}i then return nil
-    when %r{^=} then return nil
-    when %r{^PACKAGE} then return nil
-    when %r{\[1m} then return nil # Newer versions of PEAR use colorized output
-    when %r{^(\S+)\s+(\S+)\s+\S+} then
-      name = Regexp.last_match(1)
-      version = Regexp.last_match(2)
-
-      return {
-        name: "pecl-#{name.downcase}",
-        ensure: version
-      }
-    else
-      Puppet.warning format('Could not match %s', desc)
-      nil
-    end
-  end
+  has_feature :install_options
 
   def self.instances
-    pecllist(local: true).map do |hash|
-      new(hash)
+    pear_packages = super
+
+    pear_packages.select do |pkg|
+      pkg.properties[:vendor] == 'pecl.php.net'
     end
   end
 
-  def peclname
-    name.sub('pecl-', '').downcase
+  def convert_to_pear
+    @resource[:source] = "pecl.php.net/#{@resource[:name]}"
   end
 
   def install(useversion = true)
-    command = ['upgrade']
-
-    if @resource[:source]
-      command << @resource[:source]
-    elsif (!@resource.should(:ensure).is_a? Symbol) && useversion
-      command << '-f'
-      command << "#{peclname}-#{@resource.should(:ensure)}"
-    else
-      command << peclname
-    end
-
-    if @resource[:pipe]
-      command << '<<<'
-      command << @resource[:pipe]
-    end
-
-    peclcmd(*command)
+    convert_to_pear
+    super(useversion)
   end
 
   def latest
-    version = ''
-    command = [command(:peclcmd), 'remote-info', peclname]
-    execute(command).each_line do |set|
-      version = set.split[1] if set =~ %r{^Latest}
-    end
-
-    version
-  end
-
-  def query
-    self.class.pecllist(justme: peclname)
+    convert_to_pear
+    super
   end
 
   def uninstall
-    output = peclcmd 'uninstall', peclname
-    raise Puppet::Error, output unless output =~ %r{^uninstall ok}
-  end
-
-  def update
-    install(false)
+    convert_to_pear
+    super
   end
 end

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -170,7 +170,7 @@ describe 'php::extension' do
                 }
               end
 
-              it { is_expected.to contain_package('pecl-json') }
+              it { is_expected.to contain_package('json') }
               it { is_expected.to contain_package('libmemcached-dev') }
               it { is_expected.to contain_package('build-essential') }
               it do

--- a/spec/fixtures/unit/provider/package/pear/list_a
+++ b/spec/fixtures/unit/provider/package/pear/list_a
@@ -1,0 +1,22 @@
+INSTALLED PACKAGES, CHANNEL __URI:
+==================================
+(no packages installed)
+
+INSTALLED PACKAGES, CHANNEL DOC.PHP.NET:
+========================================
+(no packages installed)
+
+INSTALLED PACKAGES, CHANNEL PEAR.PHP.NET:
+=========================================
+PACKAGE          VERSION STATE
+Archive_Tar      1.4.0   stable
+Console_Getopt   1.4.1   stable
+PEAR             1.10.1  stable
+Structures_Graph 1.1.1   stable
+XML_Util         1.3.0   stable
+
+INSTALLED PACKAGES, CHANNEL PECL.PHP.NET:
+=========================================
+PACKAGE VERSION STATE
+zip     1.13.5  stable
+

--- a/spec/fixtures/unit/provider/package/pear/remote-info_benchmark
+++ b/spec/fixtures/unit/provider/package/pear/remote-info_benchmark
@@ -1,0 +1,11 @@
+PACKAGE DETAILS:
+================
+Latest      1.2.9
+Installed   - no -
+Package     Benchmark
+License     New BSD
+Category    Benchmarking
+Summary     Framework to benchmark PHP scripts or function
+            calls.
+Description Framework to benchmark PHP scripts or function
+            calls.

--- a/spec/fixtures/unit/provider/package/pear/remote-info_zip
+++ b/spec/fixtures/unit/provider/package/pear/remote-info_zip
@@ -1,0 +1,10 @@
+PACKAGE DETAILS:
+================
+Latest      1.13.5
+Installed   1.13.5
+Package     zip
+License     PHP 3.01
+Category    File Formats
+Summary     A zip management extension
+Description Zip is an extension to create, modify and read
+            zip files.

--- a/spec/unit/provider/package/pear_spec.rb
+++ b/spec/unit/provider/package/pear_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:package).provider(:pear) do
+  let(:resource) do
+    Puppet::Type.type(:package).new name: 'dummy', ensure: :installed
+  end
+
+  let(:provider) do
+    described_class.new(resource)
+  end
+
+  before do
+    described_class.stubs(:command).with(:pear).returns '/fake/pear'
+  end
+
+  describe '.instances' do
+    it 'returns an array of installed packages' do
+      described_class.expects(:pear).
+        with('list', '-a').
+        returns File.read(my_fixture('list_a'))
+
+      expect(described_class.instances.map(&:properties)).to eq [
+        { name: 'Archive_Tar',      vendor: 'pear.php.net', ensure: '1.4.0',  provider: :pear },
+        { name: 'Console_Getopt',   vendor: 'pear.php.net', ensure: '1.4.1',  provider: :pear },
+        { name: 'PEAR',             vendor: 'pear.php.net', ensure: '1.10.1', provider: :pear },
+        { name: 'Structures_Graph', vendor: 'pear.php.net', ensure: '1.1.1',  provider: :pear },
+        { name: 'XML_Util',         vendor: 'pear.php.net', ensure: '1.3.0',  provider: :pear },
+        { name: 'zip',              vendor: 'pecl.php.net', ensure: '1.13.5', provider: :pear }
+      ]
+    end
+
+    it 'ignores malformed lines' do
+      described_class.expects(:pear).
+        with('list', '-a').
+        returns 'aaa2.1'
+      Puppet.expects(:warning).with('Could not match aaa2.1')
+      expect(described_class.instances).to eq []
+    end
+  end
+
+  describe '#install' do
+    it 'installs a package' do
+      described_class.expects(:pear).
+        with('-D', 'auto_discover=1', 'upgrade', '--alldeps', 'dummy')
+      provider.install
+    end
+
+    it 'installs a specific version' do
+      resource[:ensure] = '0.2'
+      described_class.expects(:pear).
+        with('-D', 'auto_discover=1', 'upgrade', '--alldeps', '-f', 'dummy-0.2')
+      provider.install
+    end
+
+    it 'installs from a specific source' do
+      resource[:source] = 'pear.php.net/dummy'
+      described_class.expects(:pear).
+        with('-D', 'auto_discover=1', 'upgrade', '--alldeps', 'pear.php.net/dummy')
+      provider.install
+    end
+
+    it 'installs a specific version from a specific source' do
+      resource[:ensure] = '0.2'
+      resource[:source] = 'pear.php.net/dummy'
+      described_class.expects(:pear).
+        with('-D', 'auto_discover=1', 'upgrade', '--alldeps', '-f', 'pear.php.net/dummy-0.2')
+      provider.install
+    end
+
+    it 'uses the specified responsefile' do
+      resource[:responsefile] = '/fake/pearresponse'
+      Puppet::Util::Execution.expects(:execute).
+        with(
+          ['/fake/pear', '-D', 'auto_discover=1', 'upgrade', '--alldeps', 'dummy'],
+          stdinfile: resource[:responsefile]
+        )
+      provider.install
+    end
+
+    it 'accepts install_options' do
+      resource[:install_options] = ['--onlyreqdeps']
+      described_class.expects(:pear).
+        with('-D', 'auto_discover=1', 'upgrade', '--onlyreqdeps', 'dummy')
+      provider.install
+    end
+  end
+
+  describe '#query' do
+    it 'queries information about one package' do
+      described_class.expects(:pear).
+        with('list', '-a').
+        returns File.read(my_fixture('list_a'))
+
+      resource[:name] = 'pear'
+      expect(provider.query).to eq(
+        name: 'PEAR', vendor: 'pear.php.net', ensure: '1.10.1', provider: :pear
+      )
+    end
+  end
+
+  describe '#latest' do
+    it 'fetches the latest version available' do
+      described_class.expects(:pear).
+        with('remote-info', 'Benchmark').
+        returns File.read(my_fixture('remote-info_benchmark'))
+
+      resource[:name] = 'Benchmark'
+      expect(provider.latest).to eq '1.2.9'
+    end
+  end
+
+  describe '#uninstall' do
+    it 'uninstalls a package' do
+      described_class.expects(:pear).
+        with('uninstall', resource[:name]).
+        returns('uninstall ok')
+      provider.uninstall
+    end
+
+    it 'raises an error otherwise' do
+      described_class.expects(:pear).
+        with('uninstall', resource[:name]).
+        returns('unexpected output')
+      expect { provider.uninstall }.to raise_error(Puppet::Error)
+    end
+  end
+
+  describe '#update' do
+    it 'ignores the resource version' do
+      resource[:ensure] = '2.0'
+
+      described_class.expects(:pear).
+        with('-D', 'auto_discover=1', 'upgrade', '--alldeps', 'dummy')
+      provider.update
+    end
+  end
+end

--- a/spec/unit/provider/package/pecl_spec.rb
+++ b/spec/unit/provider/package/pecl_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:package).provider(:pecl) do
+  let(:resource) do
+    Puppet::Type.type(:package).new name: 'dummy', ensure: :installed
+  end
+
+  let(:provider) do
+    described_class.new(resource)
+  end
+
+  let(:parent_class) do
+    Puppet::Type::Package::ProviderPear
+  end
+
+  before do
+    parent_class.stubs(:command).with(:pear).returns '/fake/pear'
+  end
+
+  describe '.instances' do
+    it 'returns pecl installed packages via pear' do
+      parent_class.expects(:pear).
+        with('list', '-a').
+        returns File.read(fixtures('unit/provider/package/pear/list_a'))
+
+      expect(described_class.instances.map(&:properties)).to eq [
+        { ensure: '1.13.5', name: 'zip', vendor: 'pecl.php.net', provider: :pecl }
+      ]
+    end
+  end
+
+  describe '#install' do
+    it 'installs with pear' do
+      parent_class.expects(:pear)
+      provider.install
+    end
+  end
+
+  describe '#query' do
+    it 'queries pecl package info via pear' do
+      parent_class.expects(:pear).
+        with('list', '-a').
+        returns File.read(fixtures('unit/provider/package/pear/list_a'))
+
+      resource[:name] = 'zip'
+      expect(provider.query).to eq(ensure: '1.13.5', name: 'zip', vendor: 'pecl.php.net', provider: :pecl)
+    end
+  end
+
+  describe '#latest' do
+    it 'fetches the latest version available via pear' do
+      parent_class.expects(:pear).
+        with('remote-info', 'pecl.php.net/zip').
+        returns File.read(fixtures('unit/provider/package/pear/remote-info_zip'))
+
+      resource[:name] = 'zip'
+      expect(provider.latest).to eq '1.13.5'
+    end
+  end
+
+  describe '#uninstall' do
+    it 'uninstalls a package via pear' do
+      parent_class.expects(:pear).
+        returns('uninstall ok')
+      provider.uninstall
+    end
+  end
+
+  describe '#update' do
+    it 'updates to latest version via pear' do
+      resource[:ensure] = '2.0'
+
+      parent_class.expects(:pear)
+      provider.update
+    end
+  end
+end


### PR DESCRIPTION
could return info about another package

example:
```
  pry> @resource
  => Package[pecl-mongo]
  pry> self.class.pecllist(justme: peclname)
  => {:name=>"pecl-apcu", :ensure=>"4.0.7", :provider=>:peclcmd}
```

this wrongly results in pecl-mongo not being installed when needed

fixes #255 as well by returning the correct version for installed
packages

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
