### PR TITLE
composer auto_update: exec's environment must be array

### DIFF
--- a/manifests/composer/auto_update.pp
+++ b/manifests/composer/auto_update.pp
@@ -38,9 +38,9 @@ class php::composer::auto_update (
   }
 
   if $proxy_type and $proxy_server {
-    $env = {"${proxy_type}_proxy" => $proxy_server}
+    $env = [ 'HOME=/root', "${proxy_type}_proxy=${proxy_server}" ]
   } else {
-    $env = undef
+    $env = [ 'HOME=/root' ]
   }
 
   exec { 'update composer':


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

we were passing a Hash, a Hash missing HOME, at that (#303)
This fixes both issues.