### PR TITLE
Remove support for PHP 5.5 in Ubuntu

### DIFF
--- a/manifests/repo/ubuntu.pp
+++ b/manifests/repo/ubuntu.pp
@@ -16,11 +16,14 @@ class php::repo::ubuntu (
     $version_real = $version
   }
 
+  if ($version_real == '5.5') {
+    fail('PHP 5.5 is no longer available for download')
+  }
+
   validate_re($version_real, '^\d\.\d')
 
   $version_repo = $version_real ? {
     '5.4' => 'ondrej/php5-oldstable',
-    '5.5' => 'ondrej/php',
     '5.6' => 'ondrej/php',
     '7.0' => 'ondrej/php'
   }


### PR DESCRIPTION
PHP 5.5 on Ubuntu is no longer available for download from the "ondrej/php" PPA. I think we should fail the execution when people want to install it.