### PR TITLE
replace ensure_packages use with package resource

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -109,7 +109,7 @@ define php::extension (
     }
 
     if $provider == 'pecl' or $provider == 'pear' {
-      ensure_packages( [ $real_package ], {
+      package { $real_package:
         ensure       => $ensure,
         provider     => $provider,
         source       => $real_source,
@@ -118,7 +118,7 @@ define php::extension (
           Class['::php::pear'],
           Class['::php::dev'],
         ],
-      })
+      }
 
       unless empty($compiler_packages) {
         ensure_resource('package', $compiler_packages)
@@ -130,11 +130,11 @@ define php::extension (
         warning("responsefile param is not supported by php::extension provider ${provider}")
       }
 
-      ensure_packages( [ $real_package ], {
+      package { $real_package:
         ensure   => $ensure,
         provider => $provider,
         source   => $real_source,
-      })
+      }
     }
 
     $package_depends = "Package[${real_package}]"


### PR DESCRIPTION
We don't need the overly complex ensure_packages() function.
This module is designed to manage php. We should be confident in this,
and just let it do that.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
