### PR TITLE
Simplify php::extension

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -18,10 +18,6 @@
 #   The source to install the extension from. Possible values
 #   depend on the *provider* used
 #
-# [*pecl_source*]
-#   The pecl source channel to install pecl package from
-#   Superseded by *source*
-#
 # [*so_name*]
 #   The DSO name of the package (e.g. opcache for zendopcache)
 #
@@ -57,161 +53,47 @@
 #   *providers*: pear, pecl.
 #
 define php::extension (
-  $ensure            = 'installed',
-  $provider          = undef,
-  $source            = undef,
-  $pecl_source       = undef,
-  $so_name           = $name,
-  $php_api_version   = undef,
-  $package_prefix    = $::php::package_prefix,
-  $header_packages   = [],
-  $compiler_packages = $::php::params::compiler_packages,
-  $zend              = false,
-  $settings          = {},
-  $settings_prefix   = false,
-  $sapi              = 'ALL',
-  $responsefile      = undef,
+  String           $ensure            = 'installed',
+  Optional[Php::Provider] $provider   = undef,
+  Optional[String] $source            = undef,
+  Optional[String] $so_name           = downcase($name),
+  Optional[String] $php_api_version   = undef,
+  String           $package_prefix    = $::php::package_prefix,
+  Boolean          $zend              = false,
+  Hash             $settings          = {},
+  Php::Sapi        $sapi              = 'ALL',
+  Variant[Boolean, String]       $settings_prefix   = false,
+  Optional[Stdlib::AbsolutePath] $responsefile      = undef,
+  Variant[String, Array[String]] $header_packages   = [],
+  Variant[String, Array[String]] $compiler_packages = $::php::params::compiler_packages,
 ) {
 
   if ! defined(Class['php']) {
     warning('php::extension is private')
   }
 
-  validate_string($ensure)
-  validate_string($package_prefix)
-  validate_string($so_name)
-  validate_string($php_api_version)
-  validate_string($sapi)
-  validate_array($header_packages)
-  validate_bool($zend)
-
-  if $source and $pecl_source {
-    fail('Only one of $source and $pecl_source can be specified.')
+  php::extension::install { $title:
+    ensure            => $ensure,
+    provider          => $provider,
+    source            => $source,
+    responsefile      => $responsefile,
+    package_prefix    => $package_prefix,
+    header_packages   => $header_packages,
+    compiler_packages => $compiler_packages,
   }
 
-  if $source {
-    $real_source = $source
-  }
-  else {
-    $real_source = $pecl_source
-  }
-
-  if $provider != 'none' {
-    case $provider {
-      'pecl': { $real_package = $title }
-      'pear': { $real_package = $title }
-      default: { $real_package = "${package_prefix}${title}" }
-    }
-
-    unless empty($header_packages) {
-      ensure_resource('package', $header_packages)
-      Package[$header_packages] -> Package[$real_package]
-    }
-
-    if $provider == 'pecl' or $provider == 'pear' {
-      package { $real_package:
-        ensure       => $ensure,
-        provider     => $provider,
-        source       => $real_source,
-        responsefile => $responsefile,
-        require      => [
-          Class['::php::pear'],
-          Class['::php::dev'],
-        ],
-      }
-
-      unless empty($compiler_packages) {
-        ensure_resource('package', $compiler_packages)
-        Package[$compiler_packages] -> Package[$real_package]
-      }
-    }
-    else {
-      if $responsefile != undef {
-        warning("responsefile param is not supported by php::extension provider ${provider}")
-      }
-
-      package { $real_package:
-        ensure   => $ensure,
-        provider => $provider,
-        source   => $real_source,
-      }
-    }
-
-    $package_depends = "Package[${real_package}]"
-  } else {
-    $package_depends = undef
-  }
-
-  if $provider != 'pear' { # PEAR packages don't require antu further configuration, they just need to "be there".
-    if $zend == true {
-      $extension_key = 'zend_extension'
-      if $php_api_version != undef {
-        $module_path = "/usr/lib/php5/${php_api_version}/"
-      }
-      else {
-        $module_path = undef
-      }
-    }
-    else {
-      $extension_key = 'extension'
-      $module_path = undef
-    }
-
-    if $so_name != $name {
-      $lowercase_title = $so_name
-    }
-    else {
-      $lowercase_title = downcase($title)
-    }
-
-    # Ensure "<extension>." prefix is present in setting keys if requested
-    if $settings_prefix {
-      if is_string($settings_prefix) {
-        $full_settings_prefix = $settings_prefix
-      } else {
-        $full_settings_prefix = $lowercase_title
-      }
-      $full_settings = ensure_prefix($settings, "${full_settings_prefix}.")
-    } else {
-      $full_settings = $settings
-    }
-
-    $final_settings = deep_merge(
-      {"${extension_key}" => "${module_path}${so_name}.so"},
-      $full_settings
-    )
-
-    $config_root_ini = pick_default($::php::config_root_ini, $::php::params::config_root_ini)
-    ::php::config { $title:
-      file    => "${config_root_ini}/${lowercase_title}.ini",
-      config  => $final_settings,
-      require => $package_depends,
-    }
-
-    # Ubuntu/Debian systems use the mods-available folder. We need to enable
-    # settings files ourselves with php5enmod command.
-    $ext_tool_enable   = pick_default($::php::ext_tool_enable, $::php::params::ext_tool_enable)
-    $ext_tool_query    = pick_default($::php::ext_tool_query, $::php::params::ext_tool_query)
-    $ext_tool_enabled  = pick_default($::php::ext_tool_enabled, $::php::params::ext_tool_enabled)
-
-    if $::osfamily == 'Debian' and $ext_tool_enabled {
-      $cmd = "${ext_tool_enable} -s ${sapi} ${lowercase_title}"
-
-      if $sapi == 'ALL' {
-        exec { $cmd:
-          onlyif  => "${ext_tool_query} -s cli -m ${lowercase_title} | /bin/grep 'No module matches ${lowercase_title}'",
-          require =>::Php::Config[$title],
-        }
-      } else {
-        exec { $cmd:
-          onlyif  => "${ext_tool_query} -s ${sapi} -m ${lowercase_title} | /bin/grep 'No module matches ${lowercase_title}'",
-          require =>::Php::Config[$title],
-        }
-      }
-
-      if $::php::fpm {
-        Package[$::php::fpm::package] ~> Exec[$cmd]
-      }
+  # PEAR packages don't require any further configuration, they just need to "be there".
+  if $provider != 'pear' {
+    php::extension::config { $title:
+      ensure          => $ensure,
+      provider        => $provider,
+      so_name         => $so_name,
+      php_api_version => $php_api_version,
+      zend            => $zend,
+      settings        => $settings,
+      settings_prefix => $settings_prefix,
+      sapi            => $sapi,
+      subscribe       => Php::Extension::Install[$title],
     }
   }
 }

--- a/manifests/extension/config.pp
+++ b/manifests/extension/config.pp
@@ -1,0 +1,112 @@
+# Configure a PHP extension package
+#
+# === Parameters
+#
+# [*ensure*]
+#   The ensure of the package to install
+#   Could be "latest", "installed" or a pinned version
+#
+# [*provider*]
+#   The provider used to install the package
+#   Could be "pecl", "apt", "dpkg" or any other OS package provider
+#   If set to "none", no package will be installed
+#
+# [*so_name*]
+#   The DSO name of the package (e.g. opcache for zendopcache)
+#
+# [*php_api_version*]
+#   This parameter is used to build the full path to the extension
+#   directory for zend_extension in PHP < 5.5 (e.g. 20100525)
+#
+# [*header_packages*]
+#   System packages dependencies to install for extensions (e.g. for
+#   memcached libmemcached-dev on Debian)
+#
+# [*compiler_packages*]
+#   System packages dependencies to install for compiling extensions
+#   (e.g. build-essential on Debian)
+#
+# [*zend*]
+#  Boolean parameter, whether to load extension as zend_extension.
+#  Defaults to false.
+#
+# [*settings*]
+#   Nested hash of global config parameters for php.ini
+#
+# [*settings_prefix*]
+#   Boolean/String parameter, whether to prefix all setting keys with
+#   the extension name or specified name. Defaults to false.
+#
+# [*sapi*]
+#   String parameter, whether to specify ALL sapi or a specific sapi.
+#   Defaults to ALL.
+#
+define php::extension::config (
+  String                   $ensure          = 'installed',
+  Optional[Php::Provider]  $provider        = undef,
+  Optional[String]         $so_name         = downcase($name),
+  Optional[String]         $php_api_version = undef,
+  Boolean                  $zend            = false,
+  Hash                     $settings        = {},
+  Variant[Boolean, String] $settings_prefix = false,
+  Php::Sapi                $sapi            = 'ALL',
+) {
+
+  if ! defined(Class['php']) {
+    warning('php::extension::config is private')
+  }
+
+  if $zend == true {
+    $ini_name = downcase($so_name)
+    $extension_key = 'zend_extension'
+    $module_path = $php_api_version? {
+      undef   => undef,
+      default => "/usr/lib/php5/${php_api_version}/",
+    }
+  } else {
+    $ini_name = downcase($title)
+    $extension_key = 'extension'
+    $module_path = undef
+  }
+
+  # Ensure "<extension>." prefix is present in setting keys if requested
+  $full_settings = $settings_prefix? {
+    true   => ensure_prefix($settings, "${so_name}."),
+    false  => $settings,
+    String => ensure_prefix($settings, "${settings_prefix}."),
+  }
+
+  $final_settings = deep_merge(
+    {"${extension_key}" => "${module_path}${so_name}.so"},
+    $full_settings
+  )
+
+  $config_root_ini = pick_default($::php::config_root_ini, $::php::params::config_root_ini)
+  ::php::config { $title:
+    file   => "${config_root_ini}/${ini_name}.ini",
+    config => $final_settings,
+  }
+
+  # Ubuntu/Debian systems use the mods-available folder. We need to enable
+  # settings files ourselves with php5enmod command.
+  $ext_tool_enable   = pick_default($::php::ext_tool_enable, $::php::params::ext_tool_enable)
+  $ext_tool_query    = pick_default($::php::ext_tool_query, $::php::params::ext_tool_query)
+  $ext_tool_enabled  = pick_default($::php::ext_tool_enabled, $::php::params::ext_tool_enabled)
+
+  if $::osfamily == 'Debian' and $ext_tool_enabled {
+    $cmd = "${ext_tool_enable} -s ${sapi} ${so_name}"
+
+    $_sapi = $sapi? {
+      'ALL' => 'cli',
+      default => $sapi,
+    }
+    exec { $cmd:
+      onlyif  => "${ext_tool_query} -s ${_sapi} -m ${so_name} | /bin/grep 'No module matches ${so_name}'",
+      require => ::Php::Config[$title],
+    }
+
+    if $::php::fpm {
+      Package[$::php::fpm::package] ~> Exec[$cmd]
+    }
+  }
+}

--- a/manifests/extension/install.pp
+++ b/manifests/extension/install.pp
@@ -1,0 +1,85 @@
+# Install a PHP extension package
+#
+# === Parameters
+#
+# [*ensure*]
+#   The ensure of the package to install
+#   Could be "latest", "installed" or a pinned version
+#
+# [*package_prefix*]
+#   Prefix to prepend to the package name for the package provider
+#
+# [*provider*]
+#   The provider used to install the package
+#   Could be "pecl", "apt", "dpkg" or any other OS package provider
+#   If set to "none", no package will be installed
+#
+# [*source*]
+#   The source to install the extension from. Possible values
+#   depend on the *provider* used
+#
+# [*header_packages*]
+#   System packages dependencies to install for extensions (e.g. for
+#   memcached libmemcached-dev on Debian)
+#
+# [*compiler_packages*]
+#   System packages dependencies to install for compiling extensions
+#   (e.g. build-essential on Debian)
+#
+# [*responsefile*]
+#   File containing answers for interactive extension setup. Supported
+#   *providers*: pear, pecl.
+#
+define php::extension::install (
+  String           $ensure            = 'installed',
+  Optional[Php::Provider] $provider   = undef,
+  Optional[String] $source            = undef,
+  String           $package_prefix    = $::php::package_prefix,
+  Optional[Stdlib::AbsolutePath] $responsefile      = undef,
+  Variant[String, Array[String]] $header_packages   = [],
+  Variant[String, Array[String]] $compiler_packages = $::php::params::compiler_packages,
+) {
+
+  if ! defined(Class['php']) {
+    warning('php::extension::install is private')
+  }
+
+  case $provider {
+    /pecl|pear/: {
+      $real_package = $title
+
+      unless empty($header_packages) {
+        ensure_resource('package', $header_packages)
+        Package[$header_packages] -> Package[$real_package]
+      }
+      unless empty($compiler_packages) {
+        ensure_resource('package', $compiler_packages)
+        Package[$compiler_packages] -> Package[$real_package]
+      }
+
+      $package_require      = [
+        Class['::php::pear'],
+        Class['::php::dev'],
+      ]
+    }
+
+    'none' : {
+      debug("No package installed for php::extension: `${title}`.")
+    }
+
+    default: {
+      $real_package = "${package_prefix}${title}"
+      $package_require = undef
+    }
+  }
+
+  unless $provider == 'none' {
+    package { $real_package:
+      ensure       => $ensure,
+      provider     => $provider,
+      source       => $source,
+      responsefile => $responsefile,
+      require      => $package_require,
+    }
+  }
+}

--- a/types/provider.pp
+++ b/types/provider.pp
@@ -1,0 +1,28 @@
+type Php::Provider = Enum[
+  # do nothing
+  'none',
+
+  # php
+  'pecl',
+  'pear',
+
+  # Debuntu
+  'dpkg',
+  'apt',
+
+  # RHEL
+  'yum',
+  'rpm',
+  'dnf',
+  'up2date',
+
+  # Suse
+  'zypper',
+  'rug',
+
+  # FreeBSD
+  'freebsd',
+  'pkgng',
+  'ports',
+  'portupgrade',
+]

--- a/types/sapi.pp
+++ b/types/sapi.pp
@@ -1,0 +1,6 @@
+type Php::Sapi = Enum[
+  'ALL',
+  'cli',
+  'fpm',
+  'apache2',
+]


### PR DESCRIPTION
This defined type tried to do too much at once, so split the two main
concerns: installation & onfiguration.

Readability is greatly enhanced by reducing the nesting level of `if`s.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
