### PR TITLE
php::extension: restore prev behaviour wrt extension.ini naming

### DIFF
--- a/manifests/extension/config.pp
+++ b/manifests/extension/config.pp
@@ -57,17 +57,17 @@ define php::extension::config (
   }
 
   if $zend == true {
-    $ini_name = downcase($so_name)
     $extension_key = 'zend_extension'
     $module_path = $php_api_version? {
       undef   => undef,
       default => "/usr/lib/php5/${php_api_version}/",
     }
   } else {
-    $ini_name = downcase($title)
     $extension_key = 'extension'
     $module_path = undef
   }
+
+  $ini_name = downcase($so_name)
 
   # Ensure "<extension>." prefix is present in setting keys if requested
   $full_settings = $settings_prefix? {

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -175,7 +175,7 @@ describe 'php::extension' do
               it { is_expected.to contain_package('build-essential') }
               it do
                 is_expected.to contain_php__config('json').with(
-                  file: "#{etcdir}/json.ini",
+                  file: "#{etcdir}/nice_name.ini",
                   config: {
                     'extension' => 'nice_name.so',
                     'test'      => 'foo'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

previously we placed extensions= directives in their $so_name.ini
This behaviour is now restored.