### PR TITLE
[Ubuntu ppa]  Add support for php7.1 and prevent installation of php7.1 when trying to use php5.6 only

### DIFF
--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -27,7 +27,9 @@ class php::dev(
   }
 
   # Default PHP come with xml module and no seperate package for it
-  if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0  {
+  if $::operatingsystem == 'Ubuntu' and
+      ( versioncmp($::operatingsystemrelease, '16.04') >= 0 or
+        defined(Class['::php::repo::ubuntu']) and versioncmp($::php::globals::php_version, '5.6') >=0 ) {
     ensure_packages(["${php::package_prefix}xml"], {
       ensure  => present,
       require => Class['::apt::update'],

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -52,21 +52,29 @@
 #   File containing answers for interactive extension setup. Supported
 #   *providers*: pear, pecl.
 #
+# [*install_options*]
+#   An array of additional options to pass when installing an extension package
+#   These options should be specified as a string (e.g. '--flag'), a hash (e.g.
+#   {'--flag' => 'value'}), or an array where each element is either a string
+#   or a hash
+#   *providers*: apt, yum, rpm. (not available for pkg)
+#
 define php::extension (
-  String           $ensure            = 'installed',
-  Optional[Php::Provider] $provider   = undef,
-  Optional[String] $source            = undef,
-  Optional[String] $so_name           = downcase($name),
-  Optional[String] $php_api_version   = undef,
-  String           $package_prefix    = $::php::package_prefix,
-  Boolean          $zend              = false,
-  Hash             $settings          = {},
-  Php::Sapi        $sapi              = 'ALL',
-  Variant[Boolean, String]       $settings_prefix   = false,
-  Optional[Stdlib::AbsolutePath] $responsefile      = undef,
-  Variant[String, Array[String]] $header_packages   = [],
-  Variant[String, Array[String]] $compiler_packages = $::php::params::compiler_packages,
-) {
+  String                                                   $ensure            = 'installed',
+  Optional[Php::Provider]                                  $provider          = undef,
+  Optional[String]                                         $source            = undef,
+  Optional[String]                                         $so_name           = downcase($name),
+  Optional[String]                                         $php_api_version   = undef,
+  String                                                   $package_prefix    = $::php::package_prefix,
+  Boolean                                                  $zend              = false,
+  Hash                                                     $settings          = {},
+  Php::Sapi                                                $sapi              = 'ALL',
+  Variant[Boolean, String]                                 $settings_prefix   = false,
+  Optional[Stdlib::AbsolutePath]                           $responsefile      = undef,
+  Variant[String, Array[String]]                           $header_packages   = [],
+  Variant[String, Array[String]]                           $compiler_packages = $::php::params::compiler_packages,
+  Variant[String, Hash, Array[String], Array[Hash], Undef] $install_options   = undef,
+  ) {
 
   if ! defined(Class['php']) {
     warning('php::extension is private')
@@ -78,6 +86,7 @@ define php::extension (
     source            => $source,
     responsefile      => $responsefile,
     package_prefix    => $package_prefix,
+    install_options   => $install_options,
     header_packages   => $header_packages,
     compiler_packages => $compiler_packages,
   }

--- a/manifests/extension/install.pp
+++ b/manifests/extension/install.pp
@@ -32,20 +32,20 @@
 #
 # [*install_options*]
 #   An array of additional options to pass when installing an extension package
-#   These options should be specified as a string (e.g. ‘–flag’), a hash (e.g.
-#   {‘–flag’ => ‘value’}), or an array where each element is either a string
+#   These options should be specified as a string (e.g. '--flag'), a hash (e.g.
+#   {'--flag' => 'value'}), or an array where each element is either a string
 #   or a hash
 #   *providers*: apt, yum, rpm. (not available for pkg)
 #
 define php::extension::install (
-  String                         $ensure            = 'installed',
-  Optional[Php::Provider]        $provider          = undef,
-  Optional[String]               $source            = undef,
-  String                         $package_prefix    = $::php::package_prefix,
-  Optional[Stdlib::AbsolutePath] $responsefile      = undef,
-  Variant[String, Array[String]] $header_packages   = [],
-  Variant[String, Array[String]] $compiler_packages = $::php::params::compiler_packages,
-  Variant[String, Hash, Array[String], Array[Hash], Undef] $install_options = undef,
+  String                                                   $ensure            = 'installed',
+  Optional[Php::Provider]                                  $provider          = undef,
+  Optional[String]                                         $source            = undef,
+  String                                                   $package_prefix    = $::php::package_prefix,
+  Optional[Stdlib::AbsolutePath]                           $responsefile      = undef,
+  Variant[String, Array[String]]                           $header_packages   = [],
+  Variant[String, Array[String]]                           $compiler_packages = $::php::params::compiler_packages,
+  Variant[String, Hash, Array[String], Array[Hash], Undef] $install_options   = undef,
 ) {
 
   if ! defined(Class['php']) {

--- a/manifests/extension/install.pp
+++ b/manifests/extension/install.pp
@@ -30,14 +30,22 @@
 #   File containing answers for interactive extension setup. Supported
 #   *providers*: pear, pecl.
 #
+# [*install_options*]
+#   An array of additional options to pass when installing an extension package
+#   These options should be specified as a string (e.g. ‘–flag’), a hash (e.g.
+#   {‘–flag’ => ‘value’}), or an array where each element is either a string
+#   or a hash
+#   *providers*: apt, yum, rpm. (not available for pkg)
+#
 define php::extension::install (
-  String           $ensure            = 'installed',
-  Optional[Php::Provider] $provider   = undef,
-  Optional[String] $source            = undef,
-  String           $package_prefix    = $::php::package_prefix,
+  String                         $ensure            = 'installed',
+  Optional[Php::Provider]        $provider          = undef,
+  Optional[String]               $source            = undef,
+  String                         $package_prefix    = $::php::package_prefix,
   Optional[Stdlib::AbsolutePath] $responsefile      = undef,
   Variant[String, Array[String]] $header_packages   = [],
   Variant[String, Array[String]] $compiler_packages = $::php::params::compiler_packages,
+  Variant[String, Hash, Array[String], Array[Hash], Undef] $install_options = undef,
 ) {
 
   if ! defined(Class['php']) {
@@ -75,11 +83,12 @@ define php::extension::install (
 
   unless $provider == 'none' {
     package { $real_package:
-      ensure       => $ensure,
-      provider     => $provider,
-      source       => $source,
-      responsefile => $responsefile,
-      require      => $package_require,
+      ensure          => $ensure,
+      provider        => $provider,
+      source          => $source,
+      responsefile    => $responsefile,
+      require         => $package_require,
+      install_options => $install_options,
     }
   }
 }

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -44,7 +44,9 @@ class php::pear (
   validate_string($package_name)
 
   # Default PHP come with xml module and no seperate package for it
-  if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0 {
+  if $::operatingsystem == 'Ubuntu' and
+      ( versioncmp($::operatingsystemrelease, '16.04') >= 0 or
+        defined(Class['::php::repo::ubuntu']) and versioncmp($::php::globals::php_version, '5.6') >=0 ) {
     ensure_packages(["${php::package_prefix}xml"], {
       ensure  => present,
       require => Class['::apt::update'],

--- a/manifests/repo/ubuntu.pp
+++ b/manifests/repo/ubuntu.pp
@@ -23,9 +23,8 @@ class php::repo::ubuntu (
   validate_re($version_real, '^\d\.\d')
 
   $version_repo = $version_real ? {
-    '5.4' => 'ondrej/php5-oldstable',
-    '5.6' => 'ondrej/php',
-    '7.0' => 'ondrej/php'
+    '5.4'   => 'ondrej/php5-oldstable',
+    default => 'ondrej/php',
   }
 
   ::apt::ppa { "ppa:${version_repo}": }


### PR DESCRIPTION
Useful to prevent installation of php7.1-cli when installing php-apcu
in a php5.6 environment (Ubuntu + https://launchpad.net/~ondrej/+archive/ubuntu/php)
See https://github.com/oerdnj/deb.sury.org/issues/563

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
