### PR TITLE
[Ubuntu ppa] Add support for php7.1 and prevent installation of php7.1 when trying to use php5.6 only (puppet3 branch)

### DIFF
--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -27,7 +27,9 @@ class php::dev(
   }
 
   # Default PHP come with xml module and no seperate package for it
-  if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0  {
+  if $::operatingsystem == 'Ubuntu' and
+      ( versioncmp($::operatingsystemrelease, '16.04') >= 0 or
+        defined(Class['::php::repo::ubuntu']) and versioncmp($::php::globals::php_version, '5.6') >=0 ) {
     ensure_packages(["${php::package_prefix}xml"], {
       ensure  => present,
       require => Class['::apt::update'],

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -58,8 +58,8 @@
 #
 # [*install_options*]
 #   An array of additional options to pass when installing an extension package
-#   These options should be specified as a string (e.g. ‘–flag’), a hash (e.g.
-#   {‘–flag’ => ‘value’}), or an array where each element is either a string
+#   These options should be specified as a string (e.g. '--flag'), a hash (e.g.
+#   {'--flag' => 'value'}), or an array where each element is either a string
 #   or a hash
 #   *providers*: apt, yum, rpm. (not available for pkg)
 #

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -56,6 +56,13 @@
 #   File containing answers for interactive extension setup. Supported
 #   *providers*: pear, pecl.
 #
+# [*install_options*]
+#   An array of additional options to pass when installing an extension package
+#   These options should be specified as a string (e.g. ‘–flag’), a hash (e.g.
+#   {‘–flag’ => ‘value’}), or an array where each element is either a string
+#   or a hash
+#   *providers*: apt, yum, rpm. (not available for pkg)
+#
 define php::extension (
   $ensure            = 'installed',
   $provider          = undef,
@@ -71,6 +78,7 @@ define php::extension (
   $settings_prefix   = false,
   $sapi              = 'ALL',
   $responsefile      = undef,
+  $install_options   = undef,
 ) {
 
   if ! defined(Class['php']) {
@@ -131,9 +139,10 @@ define php::extension (
       }
 
       ensure_packages( [ $real_package ], {
-        ensure   => $ensure,
-        provider => $provider,
-        source   => $real_source,
+        ensure          => $ensure,
+        provider        => $provider,
+        source          => $real_source,
+        install_options => $install_options,
       })
     }
 

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -44,7 +44,9 @@ class php::pear (
   validate_string($package_name)
 
   # Default PHP come with xml module and no seperate package for it
-  if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0 {
+  if $::operatingsystem == 'Ubuntu' and
+      ( versioncmp($::operatingsystemrelease, '16.04') >= 0 or
+        defined(Class['::php::repo::ubuntu']) and versioncmp($::php::globals::php_version, '5.6') >=0 ) {
     ensure_packages(["${php::package_prefix}xml"], {
       ensure  => present,
       require => Class['::apt::update'],

--- a/manifests/repo/ubuntu.pp
+++ b/manifests/repo/ubuntu.pp
@@ -19,10 +19,8 @@ class php::repo::ubuntu (
   validate_re($version_real, '^\d\.\d')
 
   $version_repo = $version_real ? {
-    '5.4' => 'ondrej/php5-oldstable',
-    '5.5' => 'ondrej/php',
-    '5.6' => 'ondrej/php',
-    '7.0' => 'ondrej/php'
+    '5.4'   => 'ondrej/php5-oldstable',
+    default => 'ondrej/php',
   }
 
   ::apt::ppa { "ppa:${version_repo}": }


### PR DESCRIPTION
Useful to prevent installation of php7.1-cli when installing php-apcu
in a php5.6 environment (Ubuntu + https://launchpad.net/~ondrej/+archive/ubuntu/php)
See https://github.com/oerdnj/deb.sury.org/issues/563

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
