### PR TITLE
Only add a dependency on `Class['apt::update']` if `$manage_repo` is `true`

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -33,10 +33,10 @@ class php::packages (
   if $::osfamily == 'debian' {
     if $manage_repos {
       include ::apt
+      Class['::apt::update'] -> Package[$real_names]
     }
     package { $real_names:
-      ensure  => $ensure,
-      require => Class['::apt::update'],
+      ensure => $ensure,
     }
   } else {
     package { $real_names:


### PR DESCRIPTION
The change introduced in #278 seems reasonable, but it means that `Class['apt::update']` may not actually be defined.