### PR TITLE
expose fpm user and group

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ by default. Specify additional pools like so:
 For an overview of all possible parameters for `php::fpm::pool` resources
 please see [its documention](http://php.puppet.mayflower.de/php/fpm/pool.html).
 
+### Overriding php-fpm user
+
+By default, php-fpm is set up to run as Apache. If you need to customize that user, you can do that like so:
+
+```puppet
+  class { '::php':
+    fpm_user  => 'nginx',
+    fpm_group => 'nginx',
+  }
+```
+
 ### Alternative examples using Hiera
 Alternative to the Puppet DSL code examples above, you may optionally define your PHP configuration using Hiera.
 
@@ -139,6 +150,8 @@ Below are all the examples you see above, but defined in YAML format for use wit
 php::ensure: latest
 php::manage_repos: true
 php::fpm: true
+php::fpm_user: 'nginx'
+php::fpm_group: 'nginx'
 php::dev: true
 php::composer: true
 php::pear: true

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -45,6 +45,8 @@
 #
 class php::fpm (
   $ensure               = $::php::ensure,
+  $user                 = $::php::fpm_user,
+  $group                = $::php::fpm_group,
   $service_ensure       = $::php::fpm_service_ensure,
   $service_enable       = $::php::fpm_service_enable,
   $service_name         = $::php::fpm_service_name,
@@ -83,6 +85,8 @@ class php::fpm (
   }
 
   class { '::php::fpm::config':
+    user      => $user,
+    group     => $group,
     inifile   => $inifile,
     settings  => $real_settings,
     log_owner => $log_owner,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,6 +118,8 @@ class php (
   $fpm_global_pool_settings = {},
   $fpm_inifile              = $::php::params::fpm_inifile,
   $fpm_package              = undef,
+  $fpm_user                 = $::php::params::fpm_user,
+  $fpm_group                = $::php::params::fpm_group,
   $embedded                 = false,
   $dev                      = true,
   $composer                 = true,

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -50,6 +50,42 @@ describe 'php', type: :class do
         end
       end
 
+      describe 'when called with fpm_user parameter' do
+        let(:params) { { fpm_user: 'nginx' } }
+        it { is_expected.to contain_class('php::fpm').with(user: 'nginx') }
+        it { is_expected.to contain_php__fpm__pool('www').with(user: 'nginx') }
+
+        dstfile = case facts[:osfamily]
+                  when 'Debian'
+                    '/etc/php5/fpm/pool.d/www.conf'
+                  when 'Suse'
+                    '/etc/php5/fpm/pool.d/www.conf'
+                  when 'RedHat'
+                    '/etc/php-fpm.d/www.conf'
+                  when 'FreeBSD'
+                    '/usr/local/etc/php-fpm.d/www.conf'
+                  end
+
+        it { is_expected.to contain_file(dstfile).with_content(%r{user = nginx}) }
+      end
+      describe 'when called with fpm_group parameter' do
+        let(:params) { { fpm_group: 'nginx' } }
+        it { is_expected.to contain_class('php::fpm').with(group: 'nginx') }
+        it { is_expected.to contain_php__fpm__pool('www').with(group: 'nginx') }
+        dstfile = case facts[:osfamily]
+                  when 'Debian'
+                    '/etc/php5/fpm/pool.d/www.conf'
+                  when 'Suse'
+                    '/etc/php5/fpm/pool.d/www.conf'
+                  when 'RedHat'
+                    '/etc/php-fpm.d/www.conf'
+                  when 'FreeBSD'
+                    '/usr/local/etc/php-fpm.d/www.conf'
+                  end
+
+        it { is_expected.to contain_file(dstfile).with_content(%r{group = nginx}) }
+      end
+
       describe 'when fpm is disabled' do
         let(:params) { { fpm: false } }
         it { is_expected.not_to contain_class('php::fpm') }


### PR DESCRIPTION
Hey there,

The fpm user and group are not currently overridable outside of Hiera. This propagates the fpm user and group similarly to log_owner and log_group.

Redhat systems default the user to apache, but we're using nginx.

Let me know if this needs anything else. Thanks!