### PR TITLE
Allow installing PHP 7.1 on Debian

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -83,7 +83,7 @@ class php::globals (
             $fpm_service_name     = "php${globals_php_version}-fpm"
             $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
             $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix       = 'php7.0-'
+            $package_prefix       = "php${globals_php_version}-"
           }
           default: {
             $default_config_root  = '/etc/php5'


### PR DESCRIPTION
Hi,

this simple patch made installation of PHP 7.1 work for me on Debian 8 Jessie with manually configured  https://deb.sury.org/ repositories.

cheers
amette

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
