### PR TITLE
require pear in pecl file

### DIFF
--- a/lib/puppet/provider/package/pecl.rb
+++ b/lib/puppet/provider/package/pecl.rb
@@ -1,5 +1,5 @@
 require 'puppet/provider/package'
-require 'puppet/provider/package/pear'
+require_relative './pear'
 
 Puppet::Type.type(:package).provide :pecl, parent: :pear do
   desc 'Package management via `pecl`.'

--- a/lib/puppet/provider/package/pecl.rb
+++ b/lib/puppet/provider/package/pecl.rb
@@ -1,4 +1,5 @@
 require 'puppet/provider/package'
+require 'puppet/provider/package/pear'
 
 Puppet::Type.type(:package).provide :pecl, parent: :pear do
   desc 'Package management via `pecl`.'


### PR DESCRIPTION
This fixes the `pecl` provider autoloading the `pear` provider. On Puppet 4.9.4, I get the following error:
```
     Puppet::Error:
       Could not autoload puppet/type/package: Could not autoload puppet/provider/package/pecl: cannot load such file -- puppet/provider/pear
```

It doesn't seem to happen on Puppet 3. This is fixed by requiring `pear` explicitly in the `pecl` provider code.