### PR TITLE
Add optional param to prefix the extension ini filename

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -21,6 +21,9 @@
 # [*so_name*]
 #   The DSO name of the package (e.g. opcache for zendopcache)
 #
+# [*ini_prefix*]
+#   An optional filename prefix for the settings file of the extension
+#
 # [*php_api_version*]
 #   This parameter is used to build the full path to the extension
 #   directory for zend_extension in PHP < 5.5 (e.g. 20100525)
@@ -57,6 +60,7 @@ define php::extension (
   Optional[Php::Provider] $provider   = undef,
   Optional[String] $source            = undef,
   Optional[String] $so_name           = downcase($name),
+  Optional[String] $ini_prefix        = undef,
   Optional[String] $php_api_version   = undef,
   String           $package_prefix    = $::php::package_prefix,
   Boolean          $zend              = false,
@@ -88,6 +92,7 @@ define php::extension (
       ensure          => $ensure,
       provider        => $provider,
       so_name         => $so_name,
+      ini_prefix      => $ini_prefix,
       php_api_version => $php_api_version,
       zend            => $zend,
       settings        => $settings,

--- a/manifests/extension/config.pp
+++ b/manifests/extension/config.pp
@@ -14,6 +14,9 @@
 # [*so_name*]
 #   The DSO name of the package (e.g. opcache for zendopcache)
 #
+# [*ini_prefix*]
+#   An optional filename prefix for the settings file of the extension
+#
 # [*php_api_version*]
 #   This parameter is used to build the full path to the extension
 #   directory for zend_extension in PHP < 5.5 (e.g. 20100525)
@@ -45,6 +48,7 @@ define php::extension::config (
   String                   $ensure          = 'installed',
   Optional[Php::Provider]  $provider        = undef,
   Optional[String]         $so_name         = downcase($name),
+  Optional[String]         $ini_prefix      = undef,
   Optional[String]         $php_api_version = undef,
   Boolean                  $zend            = false,
   Hash                     $settings        = {},
@@ -83,7 +87,7 @@ define php::extension::config (
 
   $config_root_ini = pick_default($::php::config_root_ini, $::php::params::config_root_ini)
   ::php::config { $title:
-    file   => "${config_root_ini}/${ini_name}.ini",
+    file   => "${config_root_ini}/${ini_prefix}${ini_name}.ini",
     config => $final_settings,
   }
 

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -138,6 +138,27 @@ describe 'php::extension' do
           end
         end
 
+        context 'add ini file prefix if requested' do
+          let(:title) { 'zendopcache' }
+          let(:params) do
+            {
+              provider: 'pecl',
+              zend: true,
+              ini_prefix: '10-',
+              so_name: 'opcache'
+            }
+          end
+
+          it do
+            is_expected.to contain_php__config('zendopcache').with(
+              file: "#{etcdir}/10-opcache.ini",
+              config: {
+                'zend_extension' => 'opcache.so'
+              }
+            )
+          end
+        end
+
         context 'pecl extensions support php_api_version' do
           let(:title) { 'xdebug' }
           let(:params) do


### PR DESCRIPTION
Hey there,

So when loading extensions, sometimes it's desirable to specify the extension load order — for example loading opcache before other modules. This adds support for prefixing the extension ini filename to accomplish this.