### PR TITLE
Add missing php-fpm user and group class param docs

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -2,6 +2,12 @@
 #
 # === Parameters
 #
+# [*user*]
+#   The user that runs php-fpm
+#
+# [*group*]
+#   The group that runs php-fpm
+#
 # [*service_enable*]
 #   Enable/disable FPM service
 #

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -3,10 +3,10 @@
 # === Parameters
 #
 # [*user*]
-#   The user that runs php-fpm
+#   The user that php-fpm should run as
 #
 # [*group*]
-#   The group that runs php-fpm
+#   The group that php-fpm should run as
 #
 # [*service_enable*]
 #   Enable/disable FPM service

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -25,10 +25,10 @@
 # [*listen_mode*]
 #
 # [*user*]
-#   Which user the php-fpm process to run as
+#   The user that php-fpm should run as
 #
 # [*group*]
-#   Which group the php-fpm process to run as
+#   The group that php-fpm should run as
 #
 # [*pm*]
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,10 +43,10 @@
 #   Name of fpm package to install
 #
 # [*fpm_user*]
-#   The user that runs php-fpm
+#   The user that php-fpm should run as
 #
 # [*fpm_group*]
-#   The group that runs php-fpm
+#   The group that php-fpm should run as
 #
 # [*dev*]
 #   Install php header files, needed to install pecl modules

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,12 @@
 # [*fpm_package*]
 #   Name of fpm package to install
 #
+# [*fpm_user*]
+#   The user that runs php-fpm
+#
+# [*fpm_group*]
+#   The group that runs php-fpm
+#
 # [*dev*]
 #   Install php header files, needed to install pecl modules
 #


### PR DESCRIPTION
This change adds missing documentation for new php-fpm user and group related parameters recently added in 3fb3602d31c94304baf33cad753d1d77ee9a8fe3.

The `php::fpm::pool` docs were also updated for consistency.
