### PR TITLE
Restrict Apt test fixture version to module dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,9 @@
 fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
+    apt:
+      repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
+      ref: 2.4.0
     zypprepo: "git://github.com/deadpoint/puppet-zypprepo.git"
     inifile: "git://github.com/puppetlabs/puppetlabs-inifile.git"
     archive: "git://github.com/voxpupuli/puppet-archive.git"


### PR DESCRIPTION
This change fixes currently failing tests by restricting the puppetlabs-apt module version in `.fixtures.yml` to the latest version actually supported and defined in `metadata.json`.  

Long term, all modules included in the fixtures file should have versions defined so that the current `apt::source` parameter problem doesn't happen in the future.

Fwiw, this isn't meant to be a fix for the changes to apt::source like PR #342 is meant to be, but to fix a testing bug.