### PR TITLE
Add support for puppetlabs/apt 4.X

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -44,11 +44,14 @@ class php::repo::debian(
   }})
 
   ::apt::source { "source_php_${release}":
-    location    => $location,
-    release     => $release,
-    repos       => $repos,
-    include_src => $include_src,
-    require     => Apt::Key['php::repo::debian'],
+    location => $location,
+    release  => $release,
+    repos    => $repos,
+    include  => {
+      'src' => $include_src,
+      'deb' => true,
+    },
+    require  => Apt::Key['php::repo::debian'],
   }
 
   if ($dotdeb) {
@@ -56,10 +59,13 @@ class php::repo::debian(
     # See: http://www.dotdeb.org/instructions/
     if $release == 'wheezy-php56' {
       ::apt::source { 'dotdeb-wheezy':
-        location    => $location,
-        release     => 'wheezy',
-        repos       => $repos,
-        include_src => $include_src,
+        location => $location,
+        release  => 'wheezy',
+        repos    => $repos,
+        include  => {
+          'src' => $include_src,
+          'deb' => true,
+        },
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.1.0 < 3.0.0"
+      "version_requirement": ">= 4.1.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/inifile",


### PR DESCRIPTION
This adds support for the latest puppetlabs-apt module. The parameter in apt::source changed, this got adjusted. The API of this module doesn't change, this is "only" a major version bump for one of the dependencies.