### PR TITLE
ext_tool_query fix

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -72,6 +72,7 @@ define php::extension (
   $sapi              = 'ALL',
   $responsefile      = undef,
   $install_options   = undef,
+  $php_version = $::php::globals::php_version,
 ) {
 
   if ! defined(Class['php']) {
@@ -204,12 +205,12 @@ define php::extension (
 
     if $sapi == 'ALL' {
       exec { $cmd:
-        onlyif  => "${ext_tool_query} -s cli -m ${lowercase_title} | /bin/grep 'No module matches ${lowercase_title}'",
+        onlyif  => "${ext_tool_query} -s cli -m ${lowercase_title} -v ${php_version} | /bin/grep 'No module matches ${lowercase_title}'",
         require =>::Php::Config[$title],
       }
     } else {
       exec { $cmd:
-        onlyif  => "${ext_tool_query} -s ${sapi} -m ${lowercase_title} | /bin/grep 'No module matches ${lowercase_title}'",
+        onlyif  => "${ext_tool_query} -s ${sapi} -m ${lowercase_title} -v ${php_version} | /bin/grep 'No module matches ${lowercase_title}'",
         require =>::Php::Config[$title],
       }
     }


### PR DESCRIPTION
Phpquery tool changed at php >= 7.0 and this affects exec of phpenmod
Now it requires -v flag:

```
#/usr/sbin/phpquery -s cli -m ldap

WARNING: You need to specify version (-v) and sapi (-s)
usage: phpquery [ -d ] [ -q ] -v version_name -s sapi_name [ -m module_name ] [ -M ] [ -S ] [ -V ]
```

This fix repair it.

Compatable with prior version (php5query), -v flag ignored:
```
/usr/sbin/php5query -s cli -m ldap -v 5.6
ldap (Enabled for cli by local administrator)
```