### PR TITLE
fix default value of php::fpm::pool::access_log_format

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -135,7 +135,7 @@ define php::fpm::pool (
   $ping_path                               = undef,
   $ping_response                           = 'pong',
   $access_log                              = undef,
-  $access_log_format                       = "%R - %u %t \"%m %r\" %s",
+  $access_log_format                       = '"%R - %u %t \"%m %r\" %s"',
   $request_terminate_timeout               = '0',
   $request_slowlog_timeout                 = '0',
   $security_limit_extensions               = undef,


### PR DESCRIPTION
The default value for `php::fpm::pool::access_log_format` gets its escapes un-escaped by Puppet string management, resulting in a log line that looks like this:
```
127.0.0.1 -  04/Jul/2017:11:33:53 +0200GET /test.php404
```

this PR fixes the default value and gives you correctly formatted log lines like:
```
127.0.0.1 -  04/Jul/2017:12:36:24 +0200 "GET /test.php" 404
```