### PR TITLE
Backport of #355  remove example42/yum dependency on puppet3 branch

### DIFF
--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -9,6 +9,27 @@
 class php::repo::redhat (
   $yum_repo = 'remi_php56',
 ) {
-  contain "::yum::repo::${yum_repo}"
-  contain '::yum::repo::remi'
+
+  $releasever = $::operatingsystem ? {
+    /(?i:Amazon)/ => '6',
+    default       => '$releasever',  # Yum var
+  }
+
+  yumrepo { 'remi':
+    descr      => 'Remi\'s RPM repository for Enterprise Linux $releasever - $basearch',
+    mirrorlist => "http://rpms.remirepo.net/enterprise/${releasever}/remi/mirror",
+    enabled    => 1,
+    gpgcheck   => 1,
+    gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',
+    priority   => 1,
+  }
+
+  yumrepo { 'remi-php56':
+    descr      => 'Remi\'s PHP 5.6 RPM repository for Enterprise Linux $releasever - $basearch',
+    mirrorlist => "http://rpms.remirepo.net/enterprise/${releasever}/php56/mirror",
+    enabled    => 1,
+    gpgcheck   => 1,
+    gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',
+    priority   => 1,
+  }
 }

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -17,19 +17,19 @@ class php::repo::redhat (
 
   yumrepo { 'remi':
     descr      => 'Remi\'s RPM repository for Enterprise Linux $releasever - $basearch',
-    mirrorlist => "http://rpms.remirepo.net/enterprise/${releasever}/remi/mirror",
+    mirrorlist => "https://rpms.remirepo.net/enterprise/${releasever}/remi/mirror",
     enabled    => 1,
     gpgcheck   => 1,
-    gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',
+    gpgkey     => 'https://rpms.remirepo.net/RPM-GPG-KEY-remi',
     priority   => 1,
   }
 
   yumrepo { 'remi-php56':
     descr      => 'Remi\'s PHP 5.6 RPM repository for Enterprise Linux $releasever - $basearch',
-    mirrorlist => "http://rpms.remirepo.net/enterprise/${releasever}/php56/mirror",
+    mirrorlist => "https://rpms.remirepo.net/enterprise/${releasever}/php56/mirror",
     enabled    => 1,
     gpgcheck   => 1,
-    gpgkey     => 'http://rpms.remirepo.net/RPM-GPG-KEY-remi',
+    gpgkey     => 'https://rpms.remirepo.net/RPM-GPG-KEY-remi',
     priority   => 1,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -28,10 +28,6 @@
     {
       "name": "puppet/archive",
       "version_requirement": ">= 1.0.0 < 2.0.0"
-    },
-    {
-      "name": "example42/yum",
-      "version_requirement": ">= 2.1.28 < 3.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Hi 

This is a backport of #355 for the puppet3 branch. I directly cherry-picked the commits and for me it seems to work.

BTW doesn't #355 fixes https://github.com/voxpupuli/puppet-php/issues/284 too?

