### PR TITLE
Fix OS facts usage when selecting repo class for Ubuntu systems

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -7,7 +7,7 @@ class php::repo {
   case $facts['os']['family'] {
     'Debian': {
       # no contain here because apt does that already
-      case $facts['os']['family'] {
+      case $facts['os']['name'] {
         'Debian': {
           include ::php::repo::debian
         }

--- a/spec/classes/php_repo_spec.rb
+++ b/spec/classes/php_repo_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'php::repo', type: :class do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      describe 'when configuring a package repo' do
+        case facts[:osfamily]
+        when 'Debian'
+          case facts[:operatingsystem]
+          when 'Debian'
+            it { is_expected.to contain_class('php::repo::debian') }
+          when 'Ubuntu'
+            it { is_expected.to contain_class('php::repo::ubuntu') }
+          end
+        when 'Suse'
+          it { is_expected.to contain_class('php::repo::suse') }
+        when 'RedHat'
+          it { is_expected.to contain_class('php::repo::redhat') }
+        end
+      end
+
+    end
+  end
+end

--- a/spec/classes/php_repo_spec.rb
+++ b/spec/classes/php_repo_spec.rb
@@ -22,7 +22,6 @@ describe 'php::repo', type: :class do
           it { is_expected.to contain_class('php::repo::redhat') }
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
This fixes #373 where where Debian repositories were being
selected on Ubuntu systems.