### PR TITLE
Fix OS fact comparison for Ubuntu 12 and 14

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -98,7 +98,9 @@ class php::fpm (
 
   # Create an override to use a reload signal as trusty and utopic's
   # upstart version supports this
-  if $facts['os']['name'] == 'Ubuntu' and ($facts['os']['release']['major'] == '14') {
+  if ($facts['os']['name'] == 'Ubuntu'
+      and versioncmp($facts['os']['release']['full'], '14') >= 0
+      and versioncmp($facts['os']['release']['full'], '16') < 0) {
     if ($service_enable) {
       $fpm_override = 'reload signal USR2'
     }

--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -27,7 +27,9 @@ class php::fpm::service(
 
   $reload = "service ${service_name} reload"
 
-  if $facts['os']['name'] == 'Ubuntu' and $facts['os']['release']['major'] == '12' {
+  if ($facts['os']['name'] == 'Ubuntu'
+      and versioncmp($facts['os']['release']['full'], '12') >= 0
+      and versioncmp($facts['os']['release']['full'], '14') < 0) {
     # Precise upstart doesn't support reload signals, so use
     # regular service restart instead
     $restart = undef

--- a/spec/classes/php_fpm_service_spec.rb
+++ b/spec/classes/php_fpm_service_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'php::fpm::service', type: :class do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      let(:pre_condition) { 'class {"php": fpm => true}' }
+
+      describe 'when called with no parameters' do
+        # rubocop:disable RSpec/RepeatedExample
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_service('php5-fpm').with_ensure('running') }
+          if facts[:operatingsystem] == 'Ubuntu'
+            if facts[:operatingsystemrelease] == '12.04'
+              it { is_expected.to contain_service('php5-fpm').without_restart }
+            else
+              it { is_expected.to contain_service('php5-fpm').with_restart('service php5-fpm reload') }
+            end
+          end
+        when 'Suse'
+          it { is_expected.to contain_service('php-fpm').with_ensure('running') }
+        when 'FreeBSD'
+          it { is_expected.to contain_service('php-fpm').with_ensure('running') }
+        else
+          it { is_expected.to contain_service('php-fpm').with_ensure('running') }
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/php_fpm_spec.rb
+++ b/spec/classes/php_fpm_spec.rb
@@ -14,6 +14,13 @@ describe 'php::fpm', type: :class do
         when 'Debian'
           it { is_expected.to contain_package('php5-fpm').with_ensure('present') }
           it { is_expected.to contain_service('php5-fpm').with_ensure('running') }
+          if facts[:operatingsystem] == 'Ubuntu'
+            if facts[:operatingsystemrelease] == '14.04'
+              it { is_expected.to contain_file('/etc/init/php5-fpm.override').with_content('reload signal USR2') }
+            else
+              it { is_expected.to contain_file('/etc/init/php5-fpm.override').with_content("reload signal USR2\nmanual") }
+            end
+          end
         when 'Suse'
           it { is_expected.to contain_package('php5-fpm').with_ensure('present') }
           it { is_expected.to contain_service('php-fpm').with_ensure('running') }


### PR DESCRIPTION
This change uses `versioncmp` instead of an equality operator when
comparing Ubuntu OS facts for more compatibility between various facter
versions, and Ubuntu system versions.

Also, `$facts['os']['release']['major']` was changed to
`$facts['os']['release']['full']` to be more consistent with other
version comparisons in this module.

Fixes the issue reported in #372.
