### PR TITLE
bump dep on puppet/archive to '< 3.0.0'

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
This small PR only bumps the dependency on puppet/archive to `< 3.0.0`. The only breaking change in the new 2.0.0 series is the switch to puppet4 types, which has also been done in puppet/php, so no changes are necessary.