### PR TITLE
Remove comma in types after the last element

### DIFF
--- a/types/provider.pp
+++ b/types/provider.pp
@@ -24,5 +24,5 @@ type Php::Provider = Enum[
   'freebsd',
   'pkgng',
   'ports',
-  'portupgrade',
+  'portupgrade'
 ]

--- a/types/sapi.pp
+++ b/types/sapi.pp
@@ -2,5 +2,5 @@ type Php::Sapi = Enum[
   'ALL',
   'cli',
   'fpm',
-  'apache2',
+  'apache2'
 ]


### PR DESCRIPTION
Hi,

after upgrading to puppet 5.2 the parser is more restrict. I can not find any related topic in the release notes.

```
Info: Using configured environment 'jan'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Syntax error at ']' at /etc/puppetlabs/code/environments/jan/modules/php/types/provider.pp:28:1 on node htdocs
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```