### PR TITLE
Add remi-php71 Yum repository

### DIFF
--- a/manifests/composer/auto_update.pp
+++ b/manifests/composer/auto_update.pp
@@ -44,7 +44,8 @@ class php::composer::auto_update (
   }
 
   exec { 'update composer':
-    command     => "${path} --no-interaction --quiet self-update",
+    # touch binary when an update is attempted to update its mtime for idempotency when no update is available
+    command     => "${path} --no-interaction --quiet self-update; touch ${path}",
     environment => $env,
     onlyif      => "test `find '${path}' -mtime +${max_age}`",
     path        => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/', '/usr/local/bin', '/usr/local/sbin' ],

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -32,4 +32,13 @@ class php::repo::redhat (
     gpgkey     => 'https://rpms.remirepo.net/RPM-GPG-KEY-remi',
     priority   => 1,
   }
+
+  yumrepo { 'remi-php71':
+    descr      => 'Remi\'s PHP 7.1 RPM repository for Enterprise Linux 7 - $basearch',
+    mirrorlist => "http://rpms.remirepo.net/enterprise/7/php71/mirror",
+    enabled    => 1,
+    gpgcheck   => 1,
+    gpgkey     => 'https://rpms.remirepo.net/RPM-GPG-KEY-remi',
+    priority   => 1,
+  }
 }

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -35,7 +35,7 @@ class php::repo::redhat (
 
   yumrepo { 'remi-php71':
     descr      => 'Remi\'s PHP 7.1 RPM repository for Enterprise Linux 7 - $basearch',
-    mirrorlist => "http://rpms.remirepo.net/enterprise/7/php71/mirror",
+    mirrorlist => 'http://rpms.remirepo.net/enterprise/7/php71/mirror',
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => 'https://rpms.remirepo.net/RPM-GPG-KEY-remi',


### PR DESCRIPTION
Just added the remi-php71 yum repository in manifests/repo/redhat.pp
This is to enable installing of PHP 7.1 with the global package prefix

Caveat that it will make ensure => 'latest' install 7.1 instead of 5.6

Further changes to configure php extensions INI files in other pull requests
(7.1 extensions are now being prefixed with 20-)