### PR TITLE
Fix syntax issues with data types

### DIFF
--- a/types/provider.pp
+++ b/types/provider.pp
@@ -24,5 +24,5 @@ type Php::Provider = Enum[
   'freebsd',
   'pkgng',
   'ports',
-  'portupgrade',
+  'portupgrade' # lint:ignore:trailing_comma
 ]

--- a/types/sapi.pp
+++ b/types/sapi.pp
@@ -2,5 +2,5 @@ type Php::Sapi = Enum[
   'ALL',
   'cli',
   'fpm',
-  'apache2',
+  'apache2' # lint:ignore:trailing_comma
 ]


### PR DESCRIPTION
```
Error: Syntax error at ']' at /etc/puppetlabs/code/modules/php/types/sapi.pp:6:1
Error: Syntax error at ']' at /etc/puppetlabs/code/modules/php/types/provider.pp:28:1
```