### PR TITLE
Fixing wrong pear package name in Amazon Linux

### DIFF
--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -21,25 +21,27 @@ class php::pear (
   if $package {
     $package_name = $package
   } else {
-    case $facts['os']['family'] {
-      'Debian': {
-        # Debian is a litte stupid: The pear package is called 'php-pear'
-        # even though others are called 'php5-fpm' or 'php5-dev'
-        $package_name = "php-${::php::params::pear_package_suffix}"
-      }
-      'Amazon': {
-        # On Amazon Linux the package name is also just 'php-pear'.
-        # This would normally not be problematic but if you specify a
-        # package_prefix other than 'php' then it will fail.
-        $package_name = "php-${::php::params::pear_package_suffix}"
-      }
-      'FreeBSD': {
-        # On FreeBSD the package name is just 'pear'.
-        $package_name = $::php::params::pear_package_suffix
-      }
-      default: {
-        # This is the default for all other architectures
-        $package_name = "${::php::package_prefix}${::php::params::pear_package_suffix}"
+    if $facts['os']['name'] == 'Amazon' {
+      # On Amazon Linux the package name is also just 'php-pear'.
+      # This would normally not be problematic but if you specify a
+      # package_prefix other than 'php' then it will fail.
+      $package_name = "php-${::php::params::pear_package_suffix}"
+    }
+    else {
+      case $facts['os']['family'] {
+        'Debian': {
+          # Debian is a litte stupid: The pear package is called 'php-pear'
+          # even though others are called 'php5-fpm' or 'php5-dev'
+          $package_name = "php-${::php::params::pear_package_suffix}"
+        }
+        'FreeBSD': {
+          # On FreeBSD the package name is just 'pear'.
+          $package_name = $::php::params::pear_package_suffix
+        }
+        default: {
+          # This is the default for all other architectures
+          $package_name = "${::php::package_prefix}${::php::params::pear_package_suffix}"
+        }
       }
     }
   }


### PR DESCRIPTION
When the pear package name is defined, it is based on `$facter['os']['family']`. The problem is that Amazon Linux has 'RedHat' as os family.
I set an `if` before case searching for 'Amazon' in `$facter['os']['name']` based on the output of the facter command on Amazon instances:
```shell
$ facter os
{
  architecture => "x86_64",
  family => "RedHat",
  hardware => "x86_64",
  name => "Amazon",
  release => {
    full => "2017.09",
    major => "2017",
    minor => "09"
  },
  selinux => {
    enabled => false
  }
}
```

Extra information:
Puppet agent version: _4.10.1_
facter version: _3.6.4_
AMI Releas: _Amazon Linux AMI 2017.09.0.20170930 x86_64 HVM EBS_

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
