### PR TITLE
fix composer auto_update idempotency in case no update is available

### DIFF
--- a/manifests/composer/auto_update.pp
+++ b/manifests/composer/auto_update.pp
@@ -44,6 +44,7 @@ class php::composer::auto_update (
   }
 
   exec { 'update composer':
+    # touch binary when an update is attempted to update its mtime for idempotency when no update is available
     command     => "${path} --no-interaction --quiet self-update; touch ${path}",
     environment => $env,
     onlyif      => "test `find '${path}' -mtime +${max_age}`",

--- a/manifests/composer/auto_update.pp
+++ b/manifests/composer/auto_update.pp
@@ -44,7 +44,7 @@ class php::composer::auto_update (
   }
 
   exec { 'update composer':
-    command     => "${path} --no-interaction --quiet self-update",
+    command     => "${path} --no-interaction --quiet self-update; touch ${path}",
     environment => $env,
     onlyif      => "test `find '${path}' -mtime +${max_age}`",
     path        => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/', '/usr/local/bin', '/usr/local/sbin' ],


### PR DESCRIPTION
This fixes #402.

In case ```max_age``` has passed but no update was available we attempted to update on every run.