### PR TITLE
manage software-properties-common on ubuntu

### DIFF
--- a/manifests/repo/ubuntu.pp
+++ b/manifests/repo/ubuntu.pp
@@ -27,5 +27,7 @@ class php::repo::ubuntu (
     '7.0' => 'ondrej/php'
   }
 
-  ::apt::ppa { "ppa:${version_repo}": }
+  ::apt::ppa { "ppa:${version_repo}":
+    package_manage => true,
+  }
 }


### PR DESCRIPTION
software-properties-common is needed to add ppas on ubuntu. the
puppetlabs-apt module can manage the package. it is save to enable this,
because the module uses ensure_package: https://github.com/puppetlabs/puppetlabs-apt/blob/df40baebedf5c0c15e08f3ec78adfd760b1371ca/manifests/ppa.pp#L30

Without this, managing ppa repos at least on ubuntu 16.04 is impossible. I noticed this bug while testing with aceptance tests in https://github.com/voxpupuli/puppet-php/pull/418

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
