### PR TITLE
Fix wrongly named parameters for apt::source/key

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -20,6 +20,9 @@
 # [*dotdeb*]
 #   Enable special dotdeb handling
 #
+# [*sury*]
+#   Enable special sury handling
+#
 class php::repo::debian(
   $location     = 'http://packages.dotdeb.org',
   $release      = 'wheezy-php56',
@@ -30,6 +33,7 @@ class php::repo::debian(
     'source' => 'http://www.dotdeb.org/dotdeb.gpg',
   },
   $dotdeb       = true,
+  $sury         = true,
 ) {
 
   if $caller_module_name != $module_name {
@@ -70,7 +74,7 @@ class php::repo::debian(
     }
   }
 
-  if ($php::globals::php_version == '7.1') {
+  if ($sury and $php::globals::php_version == '7.1') {
     # Required packages for PHP 7.1 repository
     ensure_packages(['lsb-release', 'ca-certificates'], {'ensure' => 'present'})
 

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -76,16 +76,19 @@ class php::repo::debian(
 
     # Add PHP 7.1 key + repository
     apt::key { 'php::repo::debian-php71':
-      key        => 'DF3D585DB8F0EB658690A554AC0E47584A7A714D',
-      key_source => 'https://packages.sury.org/php/apt.gpg',
+      id     => 'DF3D585DB8F0EB658690A554AC0E47584A7A714D',
+      source => 'https://packages.sury.org/php/apt.gpg',
     }
 
     ::apt::source { 'source_php_71':
-      location    => 'https://packages.sury.org/php/',
-      release     => $::lsbdistcodename,
-      repos       => 'main',
-      include_src => false,
-      require     => [
+      location => 'https://packages.sury.org/php/',
+      release  => $::lsbdistcodename,
+      repos    => 'main',
+      include  => {
+        'src' => $include_src,
+        'deb' => true,
+      },
+      require  => [
         Apt::Key['php::repo::debian-php71'],
         Package['apt-transport-https', 'lsb-release', 'ca-certificates']
       ],


### PR DESCRIPTION
This PR fixes a naming issue in php::repo::debian. The parameters given to the apt::key and apt::source defined types are not valid for the puppetlabs/apt module >= 4.4.0, which this module depends on.