### PR TITLE
Allow a custom location for the php-fpm error log

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -15,6 +15,7 @@ class php::globals (
   Optional[Pattern[/^[57].[0-9]/]] $php_version = undef,
   Optional[Stdlib::Absolutepath] $config_root   = undef,
   Optional[Stdlib::Absolutepath] $fpm_pid_file  = undef,
+  Optional[String] $fpm_error_log               = undef,
 ) {
 
   $default_php_version = $facts['os']['family'] ? {
@@ -35,54 +36,54 @@ class php::globals (
       if $facts['os']['name'] == 'Ubuntu' {
         case $globals_php_version {
           /^5\.4/: {
-            $default_config_root  = '/etc/php5'
-            $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log        = '/var/log/php5-fpm.log'
-            $fpm_service_name     = 'php5-fpm'
-            $ext_tool_enable      = '/usr/sbin/php5enmod'
-            $ext_tool_query       = '/usr/sbin/php5query'
-            $package_prefix       = 'php5-'
+            $default_config_root   = '/etc/php5'
+            $default_fpm_pid_file  = "/var/run/php/php${globals_php_version}-fpm.pid"
+            $default_fpm_error_log = '/var/log/php5-fpm.log'
+            $fpm_service_name      = 'php5-fpm'
+            $ext_tool_enable       = '/usr/sbin/php5enmod'
+            $ext_tool_query        = '/usr/sbin/php5query'
+            $package_prefix        = 'php5-'
           }
           /^[57].[0-9]/: {
-            $default_config_root  = "/etc/php/${globals_php_version}"
-            $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name     = "php${globals_php_version}-fpm"
-            $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
-            $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix       = "php${globals_php_version}-"
+            $default_config_root   = "/etc/php/${globals_php_version}"
+            $default_fpm_pid_file  = "/var/run/php/php${globals_php_version}-fpm.pid"
+            $default_fpm_error_log = "/var/log/php${globals_php_version}-fpm.log"
+            $fpm_service_name      = "php${globals_php_version}-fpm"
+            $ext_tool_enable       = "/usr/sbin/phpenmod -v ${globals_php_version}"
+            $ext_tool_query        = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $package_prefix        = "php${globals_php_version}-"
           }
           default: {
             # Default php installation from Ubuntu official repository use the following paths until 16.04
             # For PPA please use the $php_version to override it.
-            $default_config_root  = '/etc/php5'
-            $default_fpm_pid_file = '/var/run/php5-fpm.pid'
-            $fpm_error_log        = '/var/log/php5-fpm.log'
-            $fpm_service_name     = 'php5-fpm'
-            $ext_tool_enable      = '/usr/sbin/php5enmod'
-            $ext_tool_query       = '/usr/sbin/php5query'
-            $package_prefix       = 'php5-'
+            $default_config_root   = '/etc/php5'
+            $default_fpm_pid_file  = '/var/run/php5-fpm.pid'
+            $default_fpm_error_log = '/var/log/php5-fpm.log'
+            $fpm_service_name      = 'php5-fpm'
+            $ext_tool_enable       = '/usr/sbin/php5enmod'
+            $ext_tool_query        = '/usr/sbin/php5query'
+            $package_prefix        = 'php5-'
           }
         }
       } else {
         case $globals_php_version {
           /^7\.[0-9]/: {
-            $default_config_root  = "/etc/php/${globals_php_version}"
-            $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name     = "php${globals_php_version}-fpm"
-            $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
-            $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix       = "php${globals_php_version}-"
+            $default_config_root   = "/etc/php/${globals_php_version}"
+            $default_fpm_pid_file  = "/var/run/php/php${globals_php_version}-fpm.pid"
+            $default_fpm_error_log = "/var/log/php${globals_php_version}-fpm.log"
+            $fpm_service_name      = "php${globals_php_version}-fpm"
+            $ext_tool_enable       = "/usr/sbin/phpenmod -v ${globals_php_version}"
+            $ext_tool_query        = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $package_prefix        = "php${globals_php_version}-"
           }
           default: {
-            $default_config_root  = '/etc/php5'
-            $default_fpm_pid_file = '/var/run/php5-fpm.pid'
-            $fpm_error_log        = '/var/log/php5-fpm.log'
-            $fpm_service_name     = 'php5-fpm'
-            $ext_tool_enable      = '/usr/sbin/php5enmod'
-            $ext_tool_query       = '/usr/sbin/php5query'
-            $package_prefix       = 'php5-'
+            $default_config_root   = '/etc/php5'
+            $default_fpm_pid_file  = '/var/run/php5-fpm.pid'
+            $default_fpm_error_log = '/var/log/php5-fpm.log'
+            $fpm_service_name      = 'php5-fpm'
+            $ext_tool_enable       = '/usr/sbin/php5enmod'
+            $ext_tool_query        = '/usr/sbin/php5query'
+            $package_prefix        = 'php5-'
           }
         }
       }
@@ -90,30 +91,33 @@ class php::globals (
     'Suse': {
       case $globals_php_version {
         /^7/: {
-          $default_config_root  = '/etc/php7'
-          $package_prefix       = 'php7-'
-          $default_fpm_pid_file = '/var/run/php7-fpm.pid'
-          $fpm_error_log        = '/var/log/php7-fpm.log'
+          $default_config_root   = '/etc/php7'
+          $package_prefix        = 'php7-'
+          $default_fpm_pid_file  = '/var/run/php7-fpm.pid'
+          $default_fpm_error_log = '/var/log/php7-fpm.log'
         }
         default: {
-          $default_config_root  = '/etc/php5'
-          $package_prefix       = 'php5-'
-          $default_fpm_pid_file = '/var/run/php5-fpm.pid'
-          $fpm_error_log        = '/var/log/php5-fpm.log'
+          $default_config_root   = '/etc/php5'
+          $package_prefix        = 'php5-'
+          $default_fpm_pid_file  = '/var/run/php5-fpm.pid'
+          $default_fpm_error_log = '/var/log/php5-fpm.log'
         }
       }
     }
     'RedHat': {
-      $default_config_root  = '/etc'
-      $default_fpm_pid_file = '/var/run/php-fpm/php-fpm.pid'
+      $default_config_root   = '/etc'
+      $default_fpm_pid_file  = '/var/run/php-fpm/php-fpm.pid'
+      $default_fpm_error_log = '/var/log/php-fpm/error.log'
     }
     'FreeBSD': {
-      $default_config_root  = '/usr/local/etc'
-      $default_fpm_pid_file = '/var/run/php-fpm.pid'
+      $default_config_root   = '/usr/local/etc'
+      $default_fpm_pid_file  = '/var/run/php-fpm.pid'
+      $default_fpm_error_log = '/var/log/php-fpm.log'
     }
     'Archlinux': {
-      $default_config_root  =  '/etc/php'
-      $default_fpm_pid_file = '/run/php-fpm/php-fpm.pid'
+      $default_config_root   = '/etc/php'
+      $default_fpm_pid_file  = '/run/php-fpm/php-fpm.pid'
+      $default_fpm_error_log = 'syslog'
     }
     default: {
       fail("Unsupported osfamily: ${facts['os']['family']}")
@@ -123,4 +127,6 @@ class php::globals (
   $globals_config_root = pick($config_root, $default_config_root)
 
   $globals_fpm_pid_file = pick($fpm_pid_file, $default_fpm_pid_file)
+
+  $globals_fpm_error_log = pick($fpm_error_log, $default_fpm_error_log)
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,7 @@ class php::params inherits php::globals {
       $dev_package_suffix      = 'dev'
       $fpm_pid_file            = $php::globals::globals_fpm_pid_file
       $fpm_config_file         = "${config_root}/fpm/php-fpm.conf"
-      $fpm_error_log           = $php::globals::fpm_error_log
+      $fpm_error_log           = $php::globals::globals_fpm_error_log
       $fpm_inifile             = "${config_root}/fpm/php.ini"
       $fpm_package_suffix      = 'fpm'
       $fpm_pool_dir            = "${config_root}/fpm/pool.d"
@@ -73,7 +73,7 @@ class php::params inherits php::globals {
       $dev_package_suffix      = 'devel'
       $fpm_pid_file            = $php::globals::globals_fpm_pid_file
       $fpm_config_file         = "${config_root}/fpm/php-fpm.conf"
-      $fpm_error_log           = $php::globals::fpm_error_log
+      $fpm_error_log           = $php::globals::globals_fpm_error_log
       $fpm_inifile             = "${config_root}/fpm/php.ini"
       $fpm_package_suffix      = 'fpm'
       $fpm_pool_dir            = "${config_root}/fpm/pool.d"
@@ -110,7 +110,7 @@ class php::params inherits php::globals {
       $dev_package_suffix      = 'devel'
       $fpm_pid_file            = $php::globals::globals_fpm_pid_file
       $fpm_config_file         = "${config_root}/php-fpm.conf"
-      $fpm_error_log           = '/var/log/php-fpm/error.log'
+      $fpm_error_log           = $php::globals::globals_fpm_error_log
       $fpm_inifile             = "${config_root}/php-fpm.ini"
       $fpm_package_suffix      = 'fpm'
       $fpm_pool_dir            = "${config_root}/php-fpm.d"
@@ -141,7 +141,7 @@ class php::params inherits php::globals {
       $dev_package_suffix      = undef
       $fpm_pid_file            = $php::globals::globals_fpm_pid_file
       $fpm_config_file         = "${config_root}/php-fpm.conf"
-      $fpm_error_log           = '/var/log/php-fpm.log'
+      $fpm_error_log           = $php::globals::globals_fpm_error_log
       $fpm_inifile             = "${config_root}/php-fpm.ini"
       $fpm_package_suffix      = undef
       $fpm_pool_dir            = "${config_root}/php-fpm.d"
@@ -167,7 +167,7 @@ class php::params inherits php::globals {
       $dev_package_suffix      = undef
       $fpm_pid_file            = '/run/php-fpm/php-fpm.pid'
       $fpm_config_file         = '/etc/php/php-fpm.conf'
-      $fpm_error_log           = 'syslog'
+      $fpm_error_log           = $php::globals::globals_fpm_error_log
       $fpm_inifile             = '/etc/php/php.ini'
       $fpm_package_suffix      = 'fpm'
       $fpm_pool_dir            = '/etc/php/php-fpm.d'


### PR DESCRIPTION
I like the possibility to choose a custom error log location, very usefull if you use something like RHSCL in combination with this module.
