### PR TITLE
Do not configure extension if ensure is absent

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -107,7 +107,7 @@ define php::extension (
   }
 
   # PEAR packages don't require any further configuration, they just need to "be there".
-  if $provider != 'pear' {
+  if $provider != 'pear' and $ensure != 'absent' {
     $_settings = $multifile_settings ? {
       true  => $settings,
       false => { downcase($title) => $settings } # emulate a hash if no multifile settings

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -189,6 +189,19 @@ describe 'php::extension' do
           it { is_expected.to contain_php__config('xdebug').with_config('zend_extension' => '/usr/lib/php5/20100525/xdebug.so') }
         end
 
+        context 'absent extension' do
+          let(:title) { 'mcrypt' }
+          let(:params) do
+            {
+              package_prefix: 'php5-',
+              ensure: 'absent'
+            }
+          end
+
+          it { is_expected.to contain_package('php5-mcrypt').with_ensure('absent') }
+          it { is_expected.not_to contain_php__config('mcrypt') }
+        end
+
         case facts[:os]['name']
         when 'Debian'
           context 'on Debian' do


### PR DESCRIPTION
Required, if I need to remove an extension.