### PR TITLE
Do not use a a hardcoded default for php::repo::debian

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -17,85 +17,25 @@
 # [*key*]
 #   Public key in apt::key format
 #
-# [*dotdeb*]
-#   Enable special dotdeb handling
-#
-# [*sury*]
-#   Enable special sury handling
-#
 class php::repo::debian(
-  $location     = 'http://packages.dotdeb.org',
-  $release      = 'wheezy-php56',
-  $repos        = 'all',
-  $include_src  = false,
-  $key          = {
-    'id'     => '6572BBEF1B5FF28B28B706837E3F070089DF5277',
-    'source' => 'http://www.dotdeb.org/dotdeb.gpg',
-  },
-  $dotdeb       = true,
-  $sury         = true,
+  String           $location     = 'https://packages.sury.org/php',
+  Optional[String] $release      = undef,
+  String           $repos        = 'main',
+  Boolean          $include_src  = false,
+  Hash             $key          = {
+    'id'     => 'DF3D585DB8F0EB658690A554AC0E47584A7A714D',
+    'source' => 'https://packages.sury.org/php/apt.gpg',
+  }
 ) {
-
   if $caller_module_name != $module_name {
     warning('php::repo::debian is private')
   }
 
-  include '::apt'
-
-  create_resources(::apt::key, { 'php::repo::debian' => {
-    id     => $key['id'],
-    source => $key['source'],
-  }})
-
-  ::apt::source { "source_php_${release}":
+  apt::source { 'php':
     location => $location,
     release  => $release,
     repos    => $repos,
-    include  => {
-      'src' => $include_src,
-      'deb' => true,
-    },
-    require  => Apt::Key['php::repo::debian'],
-  }
-
-  if ($dotdeb) {
-    # both repositories are required to work correctly
-    # See: http://www.dotdeb.org/instructions/
-    if $release == 'wheezy-php56' {
-      ::apt::source { 'dotdeb-wheezy':
-        location => $location,
-        release  => 'wheezy',
-        repos    => $repos,
-        include  => {
-          'src' => $include_src,
-          'deb' => true,
-        },
-      }
-    }
-  }
-
-  if ($sury and $php::globals::php_version == '7.1') {
-    # Required packages for PHP 7.1 repository
-    ensure_packages(['lsb-release', 'ca-certificates'], {'ensure' => 'present'})
-
-    # Add PHP 7.1 key + repository
-    apt::key { 'php::repo::debian-php71':
-      id     => 'DF3D585DB8F0EB658690A554AC0E47584A7A714D',
-      source => 'https://packages.sury.org/php/apt.gpg',
-    }
-
-    ::apt::source { 'source_php_71':
-      location => 'https://packages.sury.org/php/',
-      release  => $facts['os']['distro']['codename'],
-      repos    => 'main',
-      include  => {
-        'src' => $include_src,
-        'deb' => true,
-      },
-      require  => [
-        Apt::Key['php::repo::debian-php71'],
-        Package['apt-transport-https', 'lsb-release', 'ca-certificates']
-      ],
-    }
+    include  => { 'src' => $include_src },
+    key      => $key,
   }
 }

--- a/spec/classes/php_repo_debian_spec.rb
+++ b/spec/classes/php_repo_debian_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'php::repo::debian', type: :class do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      case facts[:osfamily]
+      when 'debian'
+        describe 'when called with no parameters on Debian' do
+          it { is_expected.to contain_apt__source('php') }
+        end
+        describe 'when called with include_src on Debian' do
+          let(:params) do
+            {
+              include_src: true
+            }
+          end
+
+          it do
+            is_expected.to contain_apt__source('php').with(
+              include: {
+                src: true
+              }
+            )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
On Debian 8 and 9 systems, the dotdeb debian 7 repo will be used by default. This shouldn't be.

Some breaking changes here since all location special handling removed for now.