### PR TITLE
Updated puppet/archive dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
+      "version_requirement": ">= 1.0.0 <= 3.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
It works fine with puppet/archive 3.0.0, though dep check is < 3.0.0. Currently only able to update with --force