### PR TITLE
Compatibility with Software collections (SCL)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,9 @@
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
-    zypprepo: "git://github.com/deadpoint/puppet-zypprepo.git"
-    inifile: "git://github.com/puppetlabs/puppetlabs-inifile.git"
-    archive: "git://github.com/voxpupuli/puppet-archive.git"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
+    zypprepo: "https://github.com/deadpoint/puppet-zypprepo.git"
+    inifile: "https://github.com/puppetlabs/puppetlabs-inifile.git"
+    archive: "https://github.com/voxpupuli/puppet-archive.git"
   symlinks:
     php: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Alternative to the Puppet DSL code examples above, you may optionally define you
 Below are all the examples you see above, but defined in YAML format for use with Hiera.
 
 ```yaml
+
 ---
 php::ensure: latest
 php::manage_repos: true
@@ -259,7 +260,7 @@ The older Ubuntu PPAs run by Ondřej have been deprecated (ondrej/php5, ondrej/p
 in favor of a new PPA: ondrej/php which contains all 3 versions of PHP: 5.5, 5.6, and 7.0
 Here's an example in hiera of getting PHP 5.6 installed with php-fpm, pear/pecl, and composer:
 
-```
+```puppet
 php::globals::php_version: '5.6'
 php::fpm: true
 php::dev: true
@@ -279,6 +280,124 @@ Apache with `mod_php` is not supported by this module. Please use
 We prefer using php-fpm. You can find an example Apache vhost in
 `manifests/apache_vhost.pp` that shows you how to use `mod_proxy_fcgi` to
 connect to php-fpm.
+
+
+### RedHat/CentOS SCL Users
+If you plan to use the SCL repositories with this module you must do the following adjustments:
+
+#### General config
+This ensures that the module will create configurations in the directory ``/etc/opt/rh/<php_version>/` (also in php.d/ 
+for extensions). Anyway you have to manage the SCL repo's by your own.
+ 
+```puppet
+class { '::php::globals':
+  php_version => 'rh-php71',
+  rhscl => true,
+}->
+class { '::php':
+  manage_repos => false
+}
+```
+
+#### Extensions
+Extensions in SCL are being installed with packages that cover 1 or more .so files. This is kinda incompatible with
+this module, since this module specifies an extension by name and derives the name of the package and the config (.ini)
+from it. To manage extensions of SCL packages you must use the following parameters:
+
+```puppet
+class { '::php':
+  ...
+  extensions  => {
+    'soap' => {
+      ini_prefix => '20-', 
+    },
+  }
+}
+```
+
+By this you tell the module to configure bz2 and calender while ensuring only the package `common`. Additionally to the 
+installation of 'common' the inifiles 'calender.ini' and 'bz2.ini' will be created by the scheme 
+`<config_file_prefix><extension_title>`.
+
+A list of commonly used modules:
+```puppet
+    {
+      extensions => {
+        'xml' => {
+          ini_prefix => '20-', 
+          multifile_settings => true,
+          settings => {
+            'dom'  => {},
+            'simplexml' => {},
+            'xmlwriter' => {},
+            'xsl' => {},
+            'wddx' => {},
+            'xmlreader' => {},
+          },
+        },
+        'soap' => {
+          ini_prefix => '20-', 
+        },
+        'imap' => {
+          ini_prefix => '20-', 
+        },
+        'intl' => {
+          ini_prefix => '20-', 
+        },
+        'gd' => {
+          ini_prefix => '20-', 
+        },   
+        'mbstring' => {
+          ini_prefix => '20-', 
+        },
+        'xmlrpc' => {
+          ini_prefix => '20-', 
+        },
+        'pdo' => {
+          ini_prefix => '20-',
+          multifile_settings => true,
+          settings => {
+              'pdo'  => {},
+              'pdo_sqlite' => {},
+              'sqlite3' => {},
+            },
+        },
+        'process' => {
+          ini_prefix => '20-',
+          multifile_settings => true,
+          settings => {
+             'posix'  => {},
+             'shmop' => {},
+             'sysvmsg' => {},
+             'sysvsem' => {},
+             'sysvshm' => {},
+          },
+        },
+        'mysqlnd' => {
+          ini_prefix => '30-',
+          multifile_settings => true,
+          settings => {
+             'mysqlnd'  => {},
+             'mysql' => {},
+             'mysqli' => {},
+             'pdo_mysql' => {},
+             'sysvshm' => {},
+          },
+        },
+        'mysqlnd' => {
+          ini_prefix => '30-',
+          multifile_settings => true,
+          settings => {
+             'mysqlnd'  => {},
+             'mysql' => {},
+             'mysqli' => {},
+             'pdo_mysql' => {},
+             'sysvshm' => {},
+          },
+        },
+      }
+    }
+```
 
 ### Facts
 

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -15,10 +15,31 @@ class php::cli(
 
   assert_private()
 
+  if $php::globals::rhscl_mode {
+    # stupid fixes for scl
+    file {'/usr/bin/pear':
+      ensure => 'link',
+      target => "${$php::params::php_bin_dir}/pear",
+    }
+
+    file {'/usr/bin/pecl':
+      ensure => 'link',
+      target => "${$php::params::php_bin_dir}/pecl",
+    }
+
+    file {'/usr/bin/php':
+      ensure => 'link',
+      target => "${$php::params::php_bin_dir}/php",
+    }
+  }
+
   $real_settings = deep_merge($settings, hiera_hash('php::cli::settings', {}))
 
-  ::php::config { 'cli':
-    file   => $inifile,
-    config => $real_settings,
+  if $inifile != $php::params::config_root_inifile {
+    # only create a cli specific inifile if the filenames are different
+    ::php::config { 'cli':
+      file   => $inifile,
+      config => $real_settings,
+    }
   }
 }

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -41,7 +41,15 @@
 #  Defaults to false.
 #
 # [*settings*]
-#   Nested hash of global config parameters for php.ini
+#   Hash of parameters for the specific extension, which will be written to the extensions config file by
+#   php::extension::config or a hash of mutliple settings files, each with parameters
+#   (multifile_settings must be true)
+#   (f.ex. {p => '..'} or {'bz2' => {..}, {'math' => {...}})
+#
+# [*multifile_settings*]
+#   Set this to true if you specify multiple setting files in *settings*. This must be used when the PHP package
+#   distribution bundles extensions in a single package (like 'common' bundles extensions 'bz2', ...) and each of
+#   the extension comes with a separate settings file.
 #
 # [*settings_prefix*]
 #   Boolean/String parameter, whether to prefix all setting keys with
@@ -62,12 +70,13 @@ define php::extension (
   String           $ensure                          = 'installed',
   Optional[Php::Provider] $provider                 = undef,
   Optional[String] $source                          = undef,
-  Optional[String] $so_name                         = downcase($name),
+  Optional[String] $so_name                         = undef,
   Optional[String] $ini_prefix                      = undef,
   Optional[String] $php_api_version                 = undef,
   String           $package_prefix                  = $php::package_prefix,
   Boolean          $zend                            = false,
-  Hash             $settings                        = {},
+  Variant[Hash, Hash[String, Hash]] $settings       = {},
+  Boolean          $multifile_settings              = false,
   Php::Sapi        $sapi                            = 'ALL',
   Variant[Boolean, String]       $settings_prefix   = false,
   Optional[Stdlib::AbsolutePath] $responsefile      = undef,
@@ -93,17 +102,29 @@ define php::extension (
 
   # PEAR packages don't require any further configuration, they just need to "be there".
   if $provider != 'pear' {
-    php::extension::config { $title:
-      ensure          => $ensure,
-      provider        => $provider,
-      so_name         => $so_name,
-      ini_prefix      => $ini_prefix,
-      php_api_version => $php_api_version,
-      zend            => $zend,
-      settings        => $settings,
-      settings_prefix => $settings_prefix,
-      sapi            => $sapi,
-      subscribe       => Php::Extension::Install[$title],
+    $_settings = $multifile_settings ? {
+      true  => $settings,
+      false => { downcase($title) => $settings } # emulate a hash if no multifile settings
+    }
+
+    $_settings.each |$settings_name, $settings_hash| {
+      $so_name = $multifile_settings ? {
+        true  => downcase($settings_name),
+        false => pick(downcase($so_name), downcase($name), downcase($settings_name)),
+      }
+
+      php::extension::config { $settings_name:
+        ensure          => $ensure,
+        provider        => $provider,
+        so_name         => $so_name,
+        ini_prefix      => $ini_prefix,
+        php_api_version => $php_api_version,
+        zend            => $zend,
+        settings        => $settings_hash,
+        settings_prefix => $settings_prefix,
+        sapi            => $sapi,
+        subscribe       => Php::Extension::Install[$title],
+      }
     }
   }
 }

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -93,6 +93,7 @@ class php::fpm (
     log_group => $log_group,
     require   => Package[$real_package],
   }
+
   contain 'php::fpm::config'
   contain 'php::fpm::service'
 

--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -111,6 +111,12 @@ class php::fpm::config(
     mode    => '0644',
   }
 
+  ensure_resource('file', ['/var/run/php-fpm/', '/var/log/php-fpm/'], {
+    ensure => directory,
+    owner => $user,
+    group => $group,
+  })
+
   file { $pool_base_dir:
     ensure => directory,
     owner  => root,
@@ -125,8 +131,10 @@ class php::fpm::config(
     }
   }
 
-  ::php::config { 'fpm':
-    file   => $inifile,
-    config => $settings,
+  if $inifile != $php::params::config_root_inifile {
+    ::php::config { 'fpm':
+      file   => $inifile,
+      config => $settings,
+    }
   }
 }

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -10,11 +10,20 @@
 #
 # [*fpm_pid_file*]
 #   Path to pid file for fpm
+#
+# [*rhscl_mode*]
+#   The mode specifies the specifics in paths for the various RedHat SCL environments so that the module is configured
+#   correctly on their pathnames.
+#
+#   Valid modes are: 'rhscl', 'remi'
+#
 
 class php::globals (
-  Optional[Pattern[/^[57].[0-9]/]] $php_version = undef,
+
+  Optional[Pattern[/^(rh-)?(php)?[57](\.)?[0-9]/]] $php_version = undef,
   Optional[Stdlib::Absolutepath] $config_root   = undef,
   Optional[Stdlib::Absolutepath] $fpm_pid_file  = undef,
+  $rhscl_mode   = undef,
 ) {
 
   $default_php_version = $facts['os']['name'] ? {
@@ -37,33 +46,33 @@ class php::globals (
       if $facts['os']['name'] == 'Ubuntu' {
         case $globals_php_version {
           /^5\.4/: {
-            $default_config_root  = '/etc/php5'
+            $default_config_root = '/etc/php5'
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log        = '/var/log/php5-fpm.log'
-            $fpm_service_name     = 'php5-fpm'
-            $ext_tool_enable      = '/usr/sbin/php5enmod'
-            $ext_tool_query       = '/usr/sbin/php5query'
-            $package_prefix       = 'php5-'
+            $fpm_error_log = '/var/log/php5-fpm.log'
+            $fpm_service_name = 'php5-fpm'
+            $ext_tool_enable = '/usr/sbin/php5enmod'
+            $ext_tool_query = '/usr/sbin/php5query'
+            $package_prefix = 'php5-'
           }
           /^[57].[0-9]/: {
-            $default_config_root  = "/etc/php/${globals_php_version}"
+            $default_config_root = "/etc/php/${globals_php_version}"
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
-            $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name     = "php${globals_php_version}-fpm"
-            $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
-            $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix       = "php${globals_php_version}-"
+            $fpm_error_log = "/var/log/php${globals_php_version}-fpm.log"
+            $fpm_service_name = "php${globals_php_version}-fpm"
+            $ext_tool_enable = "/usr/sbin/phpenmod -v ${globals_php_version}"
+            $ext_tool_query = "/usr/sbin/phpquery -v ${globals_php_version}"
+            $package_prefix = "php${globals_php_version}-"
           }
           default: {
             # Default php installation from Ubuntu official repository use the following paths until 16.04
             # For PPA please use the $php_version to override it.
-            $default_config_root  = '/etc/php5'
+            $default_config_root = '/etc/php5'
             $default_fpm_pid_file = '/var/run/php5-fpm.pid'
-            $fpm_error_log        = '/var/log/php5-fpm.log'
-            $fpm_service_name     = 'php5-fpm'
-            $ext_tool_enable      = '/usr/sbin/php5enmod'
-            $ext_tool_query       = '/usr/sbin/php5query'
-            $package_prefix       = 'php5-'
+            $fpm_error_log = '/var/log/php5-fpm.log'
+            $fpm_service_name = 'php5-fpm'
+            $ext_tool_enable = '/usr/sbin/php5enmod'
+            $ext_tool_query = '/usr/sbin/php5query'
+            $package_prefix = 'php5-'
           }
         }
       } else {
@@ -78,13 +87,13 @@ class php::globals (
             $package_prefix       = "php${globals_php_version}-"
           }
           default: {
-            $default_config_root  = '/etc/php5'
+            $default_config_root = '/etc/php5'
             $default_fpm_pid_file = '/var/run/php5-fpm.pid'
-            $fpm_error_log        = '/var/log/php5-fpm.log'
-            $fpm_service_name     = 'php5-fpm'
-            $ext_tool_enable      = '/usr/sbin/php5enmod'
-            $ext_tool_query       = '/usr/sbin/php5query'
-            $package_prefix       = 'php5-'
+            $fpm_error_log = '/var/log/php5-fpm.log'
+            $fpm_service_name = 'php5-fpm'
+            $ext_tool_enable = '/usr/sbin/php5enmod'
+            $ext_tool_query = '/usr/sbin/php5query'
+            $package_prefix = 'php5-'
           }
         }
       }
@@ -92,26 +101,50 @@ class php::globals (
     'Suse': {
       case $globals_php_version {
         /^7/: {
-          $default_config_root  = '/etc/php7'
-          $package_prefix       = 'php7-'
+          $default_config_root = '/etc/php7'
+          $package_prefix = 'php7-'
           $default_fpm_pid_file = '/var/run/php7-fpm.pid'
-          $fpm_error_log        = '/var/log/php7-fpm.log'
+          $fpm_error_log = '/var/log/php7-fpm.log'
         }
         default: {
-          $default_config_root  = '/etc/php5'
-          $package_prefix       = 'php5-'
+          $default_config_root = '/etc/php5'
+          $package_prefix = 'php5-'
           $default_fpm_pid_file = '/var/run/php5-fpm.pid'
-          $fpm_error_log        = '/var/log/php5-fpm.log'
+          $fpm_error_log = '/var/log/php5-fpm.log'
         }
       }
     }
     'RedHat': {
-      $default_config_root  = '/etc'
-      $default_fpm_pid_file = '/var/run/php-fpm/php-fpm.pid'
+      case $rhscl_mode {
+        'remi': {
+          $rhscl_root             = "/opt/remi/${php_version}/root"
+          $default_config_root    = "/etc/opt/remi/${php_version}"
+          $default_fpm_pid_file   = '/var/run/php-fpm/php-fpm.pid'
+          $package_prefix         = "${php_version}-php-"
+          $fpm_service_name       = "${php_version}-php-fpm"
+        }
+        'rhscl': {
+          $rhscl_root             = "/opt/rh/${php_version}/root"
+          $default_config_root    = "/etc/opt/rh/${php_version}" # rhscl registers contents by copy in /etc/opt/rh
+          $default_fpm_pid_file   = "/var/opt/rh/${php_version}/run/php-fpm/php-fpm.pid"
+          $package_prefix         = "${php_version}-php-"
+          $fpm_service_name       = "${php_version}-php-fpm"
+        }
+        undef: {
+          $default_config_root    = '/etc/php.d'
+          $default_fpm_pid_file   = '/var/run/php-fpm/php-fpm.pid'
+          $fpm_service_name       = undef
+          $package_prefix         = undef
+        }
+        default: {
+          fail("Unsupported rhscl_mode '${rhscl_mode}'")
+        }
+      }
     }
     'FreeBSD': {
       $default_config_root  = '/usr/local/etc'
       $default_fpm_pid_file = '/var/run/php-fpm.pid'
+      $fpm_service_name     = undef
     }
     'Archlinux': {
       $default_config_root  =  '/etc/php'
@@ -122,7 +155,6 @@ class php::globals (
     }
   }
 
-  $globals_config_root = pick($config_root, $default_config_root)
-
-  $globals_fpm_pid_file = pick($fpm_pid_file, $default_fpm_pid_file)
+  $globals_config_root    = pick($config_root, $default_config_root)
+  $globals_fpm_pid_file   = pick($fpm_pid_file, $default_fpm_pid_file)
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -101,26 +101,54 @@ class php::params inherits php::globals {
       }
     }
     'RedHat': {
-      $config_root             = $php::globals::globals_config_root
-      $config_root_ini         = "${config_root}/php.d"
-      $config_root_inifile     = "${config_root}/php.ini"
+      $config_root      = $php::globals::globals_config_root
+
+      case $php::globals::rhscl_mode {
+        'remi': {
+          $config_root_ini         = "${config_root}/php.d"
+          $config_root_inifile     = "${config_root}/php.ini"
+          $cli_inifile             = $config_root_inifile
+          $fpm_inifile             = $config_root_inifile
+          $fpm_config_file         = "${config_root}/php-fpm.conf"
+          $fpm_pool_dir            = "${config_root}/php-fpm.d"
+          $php_bin_dir             = "${php::globals::rhscl_root}/bin"
+        }
+        'rhscl': {
+          $config_root_ini         = "${config_root}/php.d"
+          $config_root_inifile     = "${config_root}/php.ini"
+          $cli_inifile             = "${config_root}/php-cli.ini"
+          $fpm_inifile             = "${config_root}/php-fpm.ini"
+          $fpm_config_file         = "${config_root}/php-fpm.conf"
+          $fpm_pool_dir            = "${config_root}/php-fpm.d"
+          $php_bin_dir             = "${php::globals::rhscl_root}/bin"
+        }
+        undef: {
+          # no rhscl
+          $config_root_ini         = $config_root
+          $config_root_inifile     = '/etc/php.ini'
+          $cli_inifile             = '/etc/php-cli.ini'
+          $fpm_inifile             = '/etc/php-fpm.ini'
+          $fpm_config_file         = '/etc/php-fpm.conf'
+          $fpm_pool_dir            = '/etc/php-fpm.d'
+        }
+        default: {
+          fail("Unsupported rhscl_mode '${php::globals::rhscl_mode}'")
+        }
+      }
+
+      $apache_inifile          = $config_root_inifile
+      $embedded_inifile        = $config_root_inifile
       $common_package_names    = []
       $common_package_suffixes = ['cli', 'common']
-      $cli_inifile             = "${config_root}/php-cli.ini"
       $dev_package_suffix      = 'devel'
       $fpm_pid_file            = $php::globals::globals_fpm_pid_file
-      $fpm_config_file         = "${config_root}/php-fpm.conf"
       $fpm_error_log           = '/var/log/php-fpm/error.log'
-      $fpm_inifile             = "${config_root}/php-fpm.ini"
       $fpm_package_suffix      = 'fpm'
-      $fpm_pool_dir            = "${config_root}/php-fpm.d"
-      $fpm_service_name        = 'php-fpm'
+      $fpm_service_name        = pick($php::globals::fpm_service_name, 'php-fpm')
       $fpm_user                = 'apache'
       $fpm_group               = 'apache'
-      $apache_inifile          = "${config_root}/php.ini"
       $embedded_package_suffix = 'embedded'
-      $embedded_inifile        = "${config_root}/php.ini"
-      $package_prefix          = 'php-'
+      $package_prefix          = pick($php::globals::package_prefix, 'php-')
       $compiler_packages       = ['gcc', 'gcc-c++', 'make']
       $manage_repos            = false
       $root_group              = 'root'

--- a/spec/classes/php_fpm_config_spec.rb
+++ b/spec/classes/php_fpm_config_spec.rb
@@ -1,3 +1,4 @@
+require 'rspec'
 require 'spec_helper'
 
 describe 'php::fpm::config' do

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -64,6 +64,11 @@ describe 'php', type: :class do
 
       describe 'when called with no parameters' do
         case facts[:osfamily]
+        when 'Suse', 'RedHat', 'CentOS'
+          it { is_expected.to contain_class('php::global') }
+        end
+
+        case facts[:osfamily]
         when 'Debian'
           it { is_expected.not_to contain_class('php::global') }
           it { is_expected.to contain_class('php::fpm') }
@@ -73,36 +78,49 @@ describe 'php', type: :class do
           it { is_expected.to contain_package(php_fpm_ackage).with_ensure('present') }
           it { is_expected.to contain_package(php_dev_ackage).with_ensure('present') }
         when 'Suse'
-          it { is_expected.to contain_class('php::global') }
           it { is_expected.to contain_package('php5').with_ensure('present') }
           it { is_expected.to contain_package('php5-devel').with_ensure('present') }
           it { is_expected.to contain_package('php5-pear').with_ensure('present') }
           it { is_expected.not_to contain_package('php5-cli') }
           it { is_expected.not_to contain_package('php5-dev') }
           it { is_expected.not_to contain_package('php-pear') }
+        when 'RedHat', 'CentOS'
+          it { is_expected.to contain_package('php-cli').with_ensure('present') }
+          it { is_expected.to contain_package('php-common').with_ensure('present') }
         end
       end
 
       describe 'when called with package_prefix parameter' do
-        let(:params) { { package_prefix: 'myphp-' } }
+        package_prefix = 'myphp-'
+        let(:params) { { package_prefix: package_prefix } }
+
+        case facts[:osfamily]
+        when 'Suse', 'RedHat', 'CentOS'
+          it { is_expected.to contain_class('php::global') }
+        end
+
+        case facts[:osfamily]
+        when 'Debian', 'RedHat', 'CentOS'
+          it { is_expected.to contain_package("#{package_prefix}cli").with_ensure('present') }
+        end
 
         case facts[:osfamily]
         when 'Debian'
           it { is_expected.not_to contain_class('php::global') }
           it { is_expected.to contain_class('php::fpm') }
-          it { is_expected.to contain_package('myphp-cli').with_ensure('present') }
-          it { is_expected.to contain_package('myphp-fpm').with_ensure('present') }
-          it { is_expected.to contain_package('myphp-dev').with_ensure('present') }
-          it { is_expected.to contain_package('php-pear').with_ensure('present') }
           it { is_expected.to contain_class('php::composer') }
+          it { is_expected.to contain_package('php-pear').with_ensure('present') }
+          it { is_expected.to contain_package("#{package_prefix}dev").with_ensure('present') }
+          it { is_expected.to contain_package("#{package_prefix}fpm").with_ensure('present') }
         when 'Suse'
-          it { is_expected.to contain_class('php::global') }
           it { is_expected.to contain_package('php5').with_ensure('present') }
-          it { is_expected.to contain_package('myphp-devel').with_ensure('present') }
-          it { is_expected.to contain_package('myphp-pear').with_ensure('present') }
-          it { is_expected.not_to contain_package('myphp-cli') }
-          it { is_expected.not_to contain_package('myphp-dev') }
+          it { is_expected.to contain_package("#{package_prefix}devel").with_ensure('present') }
+          it { is_expected.to contain_package("#{package_prefix}pear").with_ensure('present') }
+          it { is_expected.not_to contain_package("#{package_prefix}cli").with_ensure('present') }
+          it { is_expected.not_to contain_package("#{package_prefix}dev") }
           it { is_expected.not_to contain_package('php-pear') }
+        when 'RedHat', 'CentOS'
+          it { is_expected.to contain_package("#{package_prefix}common").with_ensure('present') }
         end
       end
 
@@ -188,10 +206,59 @@ describe 'php', type: :class do
 
         it { is_expected.not_to contain_class('php::fpm') }
       end
+
       describe 'when composer is disabled' do
         let(:params) { { composer: false } }
 
         it { is_expected.not_to contain_class('php::composer') }
+      end
+
+      if facts[:osfamily] == 'RedHat' || facts[:osfamily] == 'CentOS'
+        describe 'when called with global option for rhscl_mode' do
+          describe 'when called with mode "remi"' do
+            scl_php_version = 'php56'
+            rhscl_mode = 'remi'
+            let(:pre_condition) do
+              "class {'::php::globals':
+                        php_version => '#{scl_php_version}',
+                        rhscl_mode => '#{rhscl_mode}'
+              }"
+            end
+            let(:params) do
+              { settings: { 'Date/date.timezone' => 'Europe/Berlin' } }
+            end
+
+            it { is_expected.to contain_class('php::global') }
+            it { is_expected.to contain_package("#{scl_php_version}-php-cli").with_ensure('present') }
+            it { is_expected.to contain_package("#{scl_php_version}-php-common").with_ensure('present') }
+            it { is_expected.to contain_php__config('global').with(file: "/etc/opt/#{rhscl_mode}/#{scl_php_version}/php.ini") }
+            it { is_expected.not_to contain_php__config('cli') }
+
+            # see: https://github.com/voxpupuli/puppet-php/blob/master/lib/puppet/parser/functions/to_hash_settings.rb
+            it { is_expected.to contain_php__config__setting("/etc/opt/#{rhscl_mode}/#{scl_php_version}/php.ini: Date/date.timezone").with_value('Europe/Berlin') }
+          end
+
+          describe 'when called with mode "rhscl"' do
+            scl_php_version = 'rh-php56'
+            rhscl_mode = 'rhscl'
+            let(:pre_condition) do
+              "class {'::php::globals':
+                        php_version => '#{scl_php_version}',
+                        rhscl_mode => '#{rhscl_mode}'
+              }"
+            end
+            let(:params) do
+              { settings: { 'Date/date.timezone' => 'Europe/Berlin' } }
+            end
+
+            it { is_expected.to contain_class('php::global') }
+            it { is_expected.to contain_package("#{scl_php_version}-php-cli").with_ensure('present') }
+            it { is_expected.to contain_package("#{scl_php_version}-php-common").with_ensure('present') }
+            it { is_expected.to contain_php__config('global').with(file: "/etc/opt/rh/#{scl_php_version}/php.ini") }
+            it { is_expected.to contain_php__config('cli').with(file: "/etc/opt/rh/#{scl_php_version}/php-cli.ini") }
+            it { is_expected.to contain_php__config__setting("/etc/opt/rh/#{scl_php_version}/php.ini: Date/date.timezone").with_value('Europe/Berlin') }
+          end
+        end
       end
     end
   end

--- a/spec/defines/extension_rhscl_spec.rb
+++ b/spec/defines/extension_rhscl_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe 'php::extension' do
+  on_supported_os.each do |os, facts|
+    next unless facts[:osfamily] == 'RedHat' || facts[:osfamily] == 'CentOS'
+
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      describe 'with rhscl_mode "remi" enabled: install one extension' do
+        scl_php_version = 'php56'
+        rhscl_mode = 'remi'
+        configs_root = "/etc/opt/#{rhscl_mode}/#{scl_php_version}"
+
+        let(:pre_condition) do
+          "class {'::php::globals':
+                    php_version => '#{scl_php_version}',
+                    rhscl_mode => '#{rhscl_mode}'
+          }->
+          class {'::php':
+                   ensure         => installed,
+                   manage_repos   => false,
+                   fpm            => false,
+                   dev            => true, # must be true since we are using the provider => pecl (option installs header files)
+                   composer       => false,
+                   pear           => true,
+                   phpunit        => false,
+          }"
+        end
+
+        let(:title) { 'soap' }
+        let(:params) do
+          {
+            ini_prefix: '20-',
+            settings: {
+              'bz2' => {
+                'Date/date.timezone' => 'Europe/Berlin'
+              }
+            },
+            multifile_settings: true
+          }
+        end
+
+        it { is_expected.to contain_class('php::global') }
+        it { is_expected.to contain_class('php') }
+        it { is_expected.to contain_php__config('bz2').with(file: "#{configs_root}/php.d/20-bz2.ini") }
+        it { is_expected.to contain_php__config__setting("#{configs_root}/php.d/20-bz2.ini: Date/date.timezone").with_value('Europe/Berlin') }
+      end
+    end
+  end
+end

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -6,7 +6,6 @@ describe 'php::extension' do
       let :facts do
         facts
       end
-
       let(:pre_condition) { 'include php' }
 
       unless facts[:osfamily] == 'Suse' || facts[:osfamily] == 'FreeBSD' # FIXME: something is wrong on these
@@ -194,6 +193,9 @@ describe 'php::extension' do
             let(:title) { 'xdebug' }
 
             it { is_expected.to contain_php__config('xdebug').with_file("#{etcdir}/xdebug.ini") }
+
+            # note to consider: As of PHP 5.2.0, the JSON extension is bundled and compiled into PHP by default
+            # http://php.net/manual/en/json.installation.php
             context 'pecl installation' do
               let(:title) { 'json' }
               let(:params) do


### PR DESCRIPTION
This is a rebased version of #292 

Original text:

This adds RedHat SCL compatibility to this puppet module
by adding the rhscl_mode parameter to ::php::globals. By
specifying this parameter the module itself configures
path specifications on its own based on the php_version
string. Further the ::php::extensions define was extended
by the ability to prefix configs and stack up extensions
which are merged into one os package.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
