### PR TITLE
Added option to notify httpd service for mod_php

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ voxpupuli/php is a Puppet module for managing PHP with a strong focus
 on php-fpm. The module aims to use sane defaults for the supported
 architectures. We strive to support all recent versions of Debian,
 Ubuntu, RedHat/CentOS, openSUSE/SLES and FreeBSD. Managing Apache
-with `mod_php` is not supported.
+with `mod_php` is not well supported.
 
 This originally was a fork of [jippi/puppet-php](https://github.com/jippi/puppet-php)
 (nodes-php on Puppet Forge) but has since been rewritten in large parts.
@@ -274,21 +274,38 @@ running Xenial (16.04), otherwise PHP 5.6 will be installed (for other versions)
 
 ### Apache support
 
-Apache with `mod_php` is not supported by this module. Please use
+Apache with `mod_php` is not well supported by this module. Please use
 [puppetlabs/apache](https://forge.puppetlabs.com/puppetlabs/apache) instead.
 
 We prefer using php-fpm. You can find an example Apache vhost in
 `manifests/apache_vhost.pp` that shows you how to use `mod_proxy_fcgi` to
 connect to php-fpm.
 
+If you wanna give it a try nevertheless there are two attributes to configure PHP.ini for `mod_php` and restart Apache httpd when settings change:
+
+```yaml
+---
+php::apache_config: true
+php::apache::service_name: 'httpd'
+# must match the name of the `Service` resource that defines the Apache httpd daemon
+```
+
+or
+
+```puppet
+class { '::php':
+  apache_config       => true,
+  apache_service_name => 'httpd',
+}
+```
 
 ### RedHat/CentOS SCL Users
 If you plan to use the SCL repositories with this module you must do the following adjustments:
 
 #### General config
-This ensures that the module will create configurations in the directory ``/etc/opt/rh/<php_version>/` (also in php.d/ 
+This ensures that the module will create configurations in the directory `/etc/opt/rh/<php_version>/` (also in php.d/
 for extensions). Anyway you have to manage the SCL repo's by your own.
- 
+
 ```puppet
 class { '::php::globals':
   php_version => 'rh-php71',

--- a/manifests/apache_config.pp
+++ b/manifests/apache_config.pp
@@ -8,10 +8,13 @@
 # [*settings*]
 #   Hash with nested hash of key => value to set in inifile
 #
+# [*service*]
+#   opt. name of Service resource that should be notified of configuration changes
+#
 class php::apache_config(
   Stdlib::Absolutepath $inifile = $php::params::apache_inifile,
   Hash $settings                = {},
-  String $service               = nil,
+  Optional[String] $service     = undef,
 ) inherits php::params {
 
   assert_private()

--- a/manifests/apache_config.pp
+++ b/manifests/apache_config.pp
@@ -10,15 +10,25 @@
 #
 class php::apache_config(
   Stdlib::Absolutepath $inifile = $php::params::apache_inifile,
-  Hash $settings                = {}
+  Hash $settings                = {},
+  String $service               = nil,
 ) inherits php::params {
 
   assert_private()
 
   $real_settings = deep_merge($settings, hiera_hash('php::apache::settings', {}))
+  $apache_service = lookup('php::apache::service_name', String, 'first', $service)
 
-  php::config { 'apache':
-    file   => $inifile,
-    config => $real_settings,
+  if $apache_service and defined(Service[$apache_service]) {
+    php::config { 'apache':
+      file   => $inifile,
+      config => $real_settings,
+      notify => Service[$apache_service],
+    }
+  } else {
+    php::config { 'apache':
+      file   => $inifile,
+      config => $real_settings,
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,10 @@
 # [*apache_config*]
 #   Manage apache's mod_php configuration
 #
+# [*apache_service_name*]
+#   This can be set to the name of an apache Service resource, e.g. 'httpd'
+#   if module puppetlabs-apache is present
+#
 # [*proxy_type*]
 #    proxy server type (none|http|https|ftp)
 #
@@ -133,6 +137,7 @@ class php (
   String $pear_ensure                             = $php::params::pear_ensure,
   Boolean $phpunit                                = false,
   Boolean $apache_config                          = false,
+  Optional[String] $apache_service_name           = undef,
   $proxy_type                                     = undef,
   $proxy_server                                   = undef,
   Hash $extensions                                = {},
@@ -217,6 +222,7 @@ class php (
     Anchor['php::begin']
       -> class { 'php::apache_config':
         settings => $real_settings,
+        service  => $apache_service_name,
       }
     -> Anchor['php::end']
   }


### PR DESCRIPTION
#### Pull Request (PR) description

If `php::settings` are changed and Apaches `mod_php` is used the Apache httpd must be restarted to re-read the config files.

This PR adds an option to identify the name of the Puppet Service resource to enable a restart of Apache httpd.

