### PR TITLE
Update puppetlabs/apt dependency for better Ubuntu 18.04 compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 4.4.0 < 5.0.0"
+      "version_requirement": ">= 4.4.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/inifile",


### PR DESCRIPTION
#### Pull Request (PR) description
Updates metadata.json to allow puppetlabs/apt versions <6.0.0 instead of <5.0.0. Version 5.0.0 includes Ubuntu 18.04 compatibility fixes.

#### This Pull Request (PR) fixes the following issues
Fixes #467
