### PR TITLE
Problem when installing the same package with PECL and APT

### DIFF
--- a/manifests/extension/install.pp
+++ b/manifests/extension/install.pp
@@ -54,11 +54,11 @@ define php::extension::install (
 
       unless empty($header_packages) {
         ensure_resource('package', $header_packages)
-        Package[$header_packages] -> Package[$real_package]
+        Package[$header_packages] -> Package["php_${real_package}"]
       }
       unless empty($compiler_packages) {
         ensure_resource('package', $compiler_packages)
-        Package[$compiler_packages] -> Package[$real_package]
+        Package[$compiler_packages] -> Package["php_${real_package}"]
       }
 
       $package_require      = [
@@ -78,7 +78,8 @@ define php::extension::install (
   }
 
   unless $provider == 'none' {
-    package { $real_package:
+    package { "php_${real_package}":
+      name            => $real_package,
       ensure          => $ensure,
       provider        => $provider,
       source          => $source,

--- a/manifests/extension/install.pp
+++ b/manifests/extension/install.pp
@@ -51,14 +51,15 @@ define php::extension::install (
   case $provider {
     /pecl|pear/: {
       $real_package = $title
+      $real_package_class = "php_${title}"
 
       unless empty($header_packages) {
         ensure_resource('package', $header_packages)
-        Package[$header_packages] -> Package["php_${real_package}"]
+        Package[$header_packages] -> Package["${real_package_class}"]
       }
       unless empty($compiler_packages) {
         ensure_resource('package', $compiler_packages)
-        Package[$compiler_packages] -> Package["php_${real_package}"]
+        Package[$compiler_packages] -> Package["${real_package_class}"]
       }
 
       $package_require      = [
@@ -73,12 +74,13 @@ define php::extension::install (
 
     default: {
       $real_package = "${package_prefix}${title}"
+      $real_package_class = "php_${package_prefix}${title}"
       $package_require = undef
     }
   }
 
   unless $provider == 'none' {
-    package { "php_${real_package}":
+    package { "${real_package_class}":
       ensure          => $ensure,
       name            => $real_package,
       provider        => $provider,

--- a/manifests/extension/install.pp
+++ b/manifests/extension/install.pp
@@ -55,11 +55,11 @@ define php::extension::install (
 
       unless empty($header_packages) {
         ensure_resource('package', $header_packages)
-        Package[$header_packages] -> Package["${real_package_class}"]
+        Package[$header_packages] -> Package[$real_package_class]
       }
       unless empty($compiler_packages) {
         ensure_resource('package', $compiler_packages)
-        Package[$compiler_packages] -> Package["${real_package_class}"]
+        Package[$compiler_packages] -> Package[$real_package_class]
       }
 
       $package_require      = [
@@ -80,7 +80,7 @@ define php::extension::install (
   }
 
   unless $provider == 'none' {
-    package { "${real_package_class}":
+    package { $real_package_class:
       ensure          => $ensure,
       name            => $real_package,
       provider        => $provider,

--- a/manifests/extension/install.pp
+++ b/manifests/extension/install.pp
@@ -51,7 +51,7 @@ define php::extension::install (
   case $provider {
     /pecl|pear/: {
       $real_package = $title
-      $real_package_class = "php_${title}"
+      $real_package_class = "phpmod_${real_package}"
 
       unless empty($header_packages) {
         ensure_resource('package', $header_packages)
@@ -74,7 +74,7 @@ define php::extension::install (
 
     default: {
       $real_package = "${package_prefix}${title}"
-      $real_package_class = "php_${package_prefix}${title}"
+      $real_package_class = "phpmod_${package_prefix}${title}"
       $package_require = undef
     }
   }

--- a/manifests/extension/install.pp
+++ b/manifests/extension/install.pp
@@ -79,8 +79,8 @@ define php::extension::install (
 
   unless $provider == 'none' {
     package { "php_${real_package}":
-      name            => $real_package,
       ensure          => $ensure,
+      name            => $real_package,
       provider        => $provider,
       source          => $source,
       responsefile    => $responsefile,

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -43,7 +43,7 @@ describe 'php::extension' do
             }
           end
 
-          it { is_expected.to contain_package('php_php5-json') }
+          it { is_expected.to contain_package('phpmod_php5-json') }
           it do
             is_expected.to contain_php__config('json').with(
               file: "#{etcdir}/json.ini",
@@ -209,9 +209,9 @@ describe 'php::extension' do
                 }
               end
 
-              it { is_expected.to contain_package('php_json') }
-              it { is_expected.to contain_package('php_libmemcached-dev') }
-              it { is_expected.to contain_package('php_build-essential') }
+              it { is_expected.to contain_package('phpmod_json') }
+              it { is_expected.to contain_package('libmemcached-dev') }
+              it { is_expected.to contain_package('build-essential') }
               it do
                 is_expected.to contain_php__config('json').with(
                   file: "#{etcdir}/nice_name.ini",

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -43,7 +43,7 @@ describe 'php::extension' do
             }
           end
 
-          it { is_expected.to contain_package('php5-json') }
+          it { is_expected.to contain_package('php_php5-json') }
           it do
             is_expected.to contain_php__config('json').with(
               file: "#{etcdir}/json.ini",
@@ -209,9 +209,9 @@ describe 'php::extension' do
                 }
               end
 
-              it { is_expected.to contain_package('json') }
-              it { is_expected.to contain_package('libmemcached-dev') }
-              it { is_expected.to contain_package('build-essential') }
+              it { is_expected.to contain_package('php_json') }
+              it { is_expected.to contain_package('php_libmemcached-dev') }
+              it { is_expected.to contain_package('php_build-essential') }
               it do
                 is_expected.to contain_php__config('json').with(
                   file: "#{etcdir}/nice_name.ini",


### PR DESCRIPTION
#### Pull Request (PR) description
If you want to install a package with PECL and APT on the same node (ex: memcached), an error appears because Package["memcached"] is already defined. By prefixing the class name and specifying the "name" key, this problem is solved.

#### This Pull Request (PR) fixes the following issues
Fixes #320
