### PR TITLE
Fix enable extension when there is no module associated

### DIFF
--- a/manifests/extension/config.pp
+++ b/manifests/extension/config.pp
@@ -108,13 +108,15 @@ define php::extension::config (
       'ALL' => 'cli',
       default => $sapi,
     }
-    exec { $cmd:
-      onlyif  => "${ext_tool_query} -s ${_sapi} -m ${so_name} | /bin/grep 'No module matches ${so_name}'",
-      require => ::Php::Config[$title],
-    }
+    if has_key($final_settings, 'extension') and $final_settings[extension] {
+      exec { $cmd:
+        onlyif  => "${ext_tool_query} -s ${_sapi} -m ${so_name} | /bin/grep 'No module matches ${so_name}'",
+        require => ::Php::Config[$title],
+      }
 
-    if $php::fpm {
-      Package[$php::fpm::package] ~> Exec[$cmd]
+      if $php::fpm {
+        Package[$php::fpm::package] ~> Exec[$cmd]
+      }
     }
   }
 }

--- a/spec/acceptance/php_spec.rb
+++ b/spec/acceptance/php_spec.rb
@@ -33,18 +33,41 @@ describe 'php with default settings' do
     end
   end
   context 'default parameters with extensions' do
-    it 'works with defaults' do
-      pp = <<-EOS
-      class{'php':
-        extensions => {
-        'mysql'    => {},
-        'gd'       => {}
+    case default[:platform]
+    when %r{ubuntu-18.04}, %r{ubuntu-16.04}, %r{ubuntu-14.04}
+      it 'works with defaults' do
+        pp = <<-EOS
+        class{'php':
+          extensions => {
+            'mysql'    => {},
+            'gd'       => {},
+            'net-url'  => {
+              package_prefix => 'php-',
+              settings       => {
+                extension => undef
+              }
+            }
+          }
         }
-      }
-      EOS
-      # Run it twice and test for idempotency
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+        EOS
+        # Run it twice and test for idempotency
+        apply_manifest(pp, catch_failures: true)
+        apply_manifest(pp, catch_changes: true)
+      end
+    else
+      it 'works with defaults' do
+        pp = <<-EOS
+        class{'php':
+          extensions => {
+            'mysql'    => {},
+            'gd'       => {}
+          }
+        }
+        EOS
+        # Run it twice and test for idempotency
+        apply_manifest(pp, catch_failures: true)
+        apply_manifest(pp, catch_changes: true)
+      end
     end
 
     case default[:platform]


### PR DESCRIPTION
When the extension has no module associated (e.g. with net-curl), the
module always run phpenmod command (because phpquery always report that
the module is not matched).
This commit tries to fix this problem