### PR TITLE
Allow `clear_env` to be disabled

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -152,7 +152,7 @@ define php::fpm::pool (
   $include                                 = undef,
   $env                                     = [],
   $env_value                               = {},
-	$clear_env                               = undef,
+  $clear_env                               = true,
   $options                                 = {},
   $php_value                               = {},
   $php_flag                                = {},

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -88,6 +88,9 @@
 #   Hash of environment variables and values as strings to use in php
 #   scripts in this pool
 #
+# [*clear_env*]
+#   Whether the environment should be cleared.
+#
 # [*options*]
 #   An optional hash for any other data.
 #
@@ -149,6 +152,7 @@ define php::fpm::pool (
   $include                                 = undef,
   $env                                     = [],
   $env_value                               = {},
+	$clear_env                               = undef,
   $options                                 = {},
   $php_value                               = {},
   $php_flag                                = {},

--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -304,6 +304,7 @@ include=<%= @include %>
 ;env[TMP] = /tmp
 ;env[TMPDIR] = /tmp
 ;env[TEMP] = /tmp
+<% if @clear_env -%>
 <% @env.each do |var| -%>
 env[<%= var %>] = $<%= var %>
 <% end -%>
@@ -311,6 +312,9 @@ env[<%= var %>] = $<%= var %>
 <% if !value.empty? -%>
 env[<%= key %>] = '<%= value %>'
 <% end -%>
+<% end -%>
+<% else -%>
+clear_env = no
 <% end -%>
 
 ; Additional php.ini defines, specific to this pool of workers. These settings


### PR DESCRIPTION
Allow `clear_env` to be disabled for PHP-FPM pool definitions.