### PR TITLE
Remove readable for others on pool config file

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -193,7 +193,7 @@ define php::fpm::pool (
       content => template($template),
       owner   => root,
       group   => $root_group,
-      mode    => '0644',
+      mode    => '0640',
     }
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
The pool config does not need to be readable by others. This allows putting secrets into the files, without them being exposed. It might make sense to make this configurable.
