### PR TITLE
Make a file-resource so we can purge the config dir of unmanaged files

### DIFF
--- a/manifests/extension/config.pp
+++ b/manifests/extension/config.pp
@@ -91,6 +91,10 @@ define php::extension::config (
 
   $config_root_ini = pick_default($php::config_root_ini, $php::params::config_root_ini)
   if $ensure == 'present' or $ensure == 'installed' or $ensure == 'latest' {
+    # Make sure a file resource is created
+    # The file is now managed and is not removed when we purge all unmanaged files
+    ensure_resource('file', "${config_root_ini}/${ini_prefix}${ini_name}.ini", {'ensure' => 'present' })
+
     ::php::config { $title:
       file   => "${config_root_ini}/${ini_prefix}${ini_name}.ini",
       config => $final_settings,


### PR DESCRIPTION
Tested on CentOS 7

ini_setting is great but the file is not managed (just the 1 line) so when we purge the config directory the file is removed. 

With this PR a file is managed and we can clear the config directory with purge.