### PR TITLE
Simplify ensure check

### DIFF
--- a/manifests/extension/config.pp
+++ b/manifests/extension/config.pp
@@ -90,7 +90,7 @@ define php::extension::config (
   }
 
   $config_root_ini = pick_default($php::config_root_ini, $php::params::config_root_ini)
-  if $ensure == 'present' or $ensure == 'installed' or $ensure == 'latest' {
+  if $ensure != 'absent' {
     ::php::config { $title:
       file   => "${config_root_ini}/${ini_prefix}${ini_name}.ini",
       config => $final_settings,


### PR DESCRIPTION
According to #478 comments, `$ensure` could have a lot of different values. This commit just checks that it has a value different than `absent`.