### PR TITLE
Fix extension config for zend_extensions

### DIFF
--- a/manifests/extension/config.pp
+++ b/manifests/extension/config.pp
@@ -109,7 +109,7 @@ define php::extension::config (
         'ALL' => 'cli',
         default => $sapi,
       }
-      if has_key($final_settings, 'extension') and $final_settings[extension] {
+      if has_key($final_settings, $extension_key) and $final_settings[$extension_key] {
         exec { $cmd:
           onlyif  => "${ext_tool_query} -s ${_sapi} -m ${so_name} | /bin/grep 'No module matches ${so_name}'",
           require => ::Php::Config[$title],


### PR DESCRIPTION
Fixes a glitch introduced in #479.

When an extension is `zend = true`, there is no `extension` entry in the `$final_settings` hash, but a `zend_extension` one.

/cc @amateo
