### PR TITLE
Fix php::fpm eternal reload for mysqli a simplexml extension

### DIFF
--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -78,7 +78,7 @@ define php::extension (
   Optional[String] $ini_prefix                      = undef,
   Optional[String] $php_api_version                 = undef,
   String           $package_prefix                  = $php::package_prefix,
-  Optional[String] $package_name                    = undef,
+  Optional[String[1]] $package_name                 = undef,
   Boolean          $zend                            = false,
   Variant[Hash, Hash[String, Hash]] $settings       = {},
   Boolean          $multifile_settings              = false,

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -9,6 +9,10 @@
 # [*package_prefix*]
 #   Prefix to prepend to the package name for the package provider
 #
+# [*package_name*]
+#   Full package name for the package provider (e.g. php7.2-xml for
+#   simlexml extension)
+#
 # [*provider*]
 #   The provider used to install the package
 #   Could be "pecl", "apt", "dpkg" or any other OS package provider
@@ -74,6 +78,7 @@ define php::extension (
   Optional[String] $ini_prefix                      = undef,
   Optional[String] $php_api_version                 = undef,
   String           $package_prefix                  = $php::package_prefix,
+  Optional[String] $package_name                    = undef,
   Boolean          $zend                            = false,
   Variant[Hash, Hash[String, Hash]] $settings       = {},
   Boolean          $multifile_settings              = false,
@@ -95,6 +100,7 @@ define php::extension (
     source            => $source,
     responsefile      => $responsefile,
     package_prefix    => $package_prefix,
+    package_name      => $package_name,
     header_packages   => $header_packages,
     compiler_packages => $compiler_packages,
     install_options   => $install_options,

--- a/manifests/extension/install.pp
+++ b/manifests/extension/install.pp
@@ -86,13 +86,15 @@ define php::extension::install (
   }
 
   unless $provider == 'none' {
-    ensure_resource('package', $real_package, {
-      ensure          => $ensure,
-      provider        => $provider,
-      source          => $source,
-      responsefile    => $responsefile,
-      install_options => $install_options,
-      require         => $package_require,
-    })
+    if ! defined(Package[$real_package]) {
+      package { $real_package:
+        ensure          => $ensure,
+        provider        => $provider,
+        source          => $source,
+        responsefile    => $responsefile,
+        install_options => $install_options,
+        require         => $package_require,
+      }
+    }
   }
 }

--- a/manifests/extension/install.pp
+++ b/manifests/extension/install.pp
@@ -9,6 +9,10 @@
 # [*package_prefix*]
 #   Prefix to prepend to the package name for the package provider
 #
+# [*package_name*]
+#   Full package name for the package provider (e.g. php7.2-xml for
+#   simlexml extension)
+#
 # [*provider*]
 #   The provider used to install the package
 #   Could be "pecl", "apt", "dpkg" or any other OS package provider
@@ -38,6 +42,7 @@ define php::extension::install (
   Optional[Php::Provider] $provider                 = undef,
   Optional[String] $source                          = undef,
   String           $package_prefix                  = $php::package_prefix,
+  Optional[String] $package_name                    = undef,
   Optional[Stdlib::AbsolutePath] $responsefile      = undef,
   Variant[String, Array[String]] $header_packages   = [],
   Variant[String, Array[String]] $compiler_packages = $php::params::compiler_packages,
@@ -72,7 +77,10 @@ define php::extension::install (
     }
 
     default: {
-      $real_package = "${package_prefix}${title}"
+      $real_package = $package_name ? {
+        undef   => "${package_prefix}${title}",
+        default => $package_name,
+      }
       $package_require = undef
     }
   }

--- a/manifests/extension/install.pp
+++ b/manifests/extension/install.pp
@@ -42,7 +42,7 @@ define php::extension::install (
   Optional[Php::Provider] $provider                 = undef,
   Optional[String] $source                          = undef,
   String           $package_prefix                  = $php::package_prefix,
-  Optional[String] $package_name                    = undef,
+  Optional[String[1]] $package_name                 = undef,
   Optional[Stdlib::AbsolutePath] $responsefile      = undef,
   Variant[String, Array[String]] $header_packages   = [],
   Variant[String, Array[String]] $compiler_packages = $php::params::compiler_packages,

--- a/manifests/extension/install.pp
+++ b/manifests/extension/install.pp
@@ -86,13 +86,13 @@ define php::extension::install (
   }
 
   unless $provider == 'none' {
-    package { $real_package:
+    ensure_resource('package', $real_package, {
       ensure          => $ensure,
       provider        => $provider,
       source          => $source,
       responsefile    => $responsefile,
       install_options => $install_options,
       require         => $package_require,
-    }
+    })
   }
 }

--- a/spec/acceptance/php_spec.rb
+++ b/spec/acceptance/php_spec.rb
@@ -46,6 +46,7 @@ describe 'php with default settings' do
               settings       => {
                 extension => undef
               },
+            }
             'simplexml'  => {
               package_name => 'php-xml'
             }

--- a/spec/acceptance/php_spec.rb
+++ b/spec/acceptance/php_spec.rb
@@ -54,7 +54,7 @@ describe 'php with default settings' do
               settings       => {
                 extension => undef
               },
-            }
+            },
             'simplexml'  => {
               package_name => '#{simplexmlpackagename}',
             }

--- a/spec/acceptance/php_spec.rb
+++ b/spec/acceptance/php_spec.rb
@@ -56,7 +56,7 @@ describe 'php with default settings' do
               },
             }
             'simplexml'  => {
-              package_name => simplexmlpackagename,
+              package_name => '#{simplexmlpackagename}',
             }
           }
         }

--- a/spec/acceptance/php_spec.rb
+++ b/spec/acceptance/php_spec.rb
@@ -36,6 +36,14 @@ describe 'php with default settings' do
     case default[:platform]
     when %r{ubuntu-18.04}, %r{ubuntu-16.04}, %r{ubuntu-14.04}
       it 'works with defaults' do
+        case default[:platform]
+        when %r{ubuntu-18.04}
+          simplexmlpackagename = 'php7.2-xml'
+        when %r{ubuntu-16.04}
+          simplexmlpackagename = 'php7.0-xml'
+        when %r{ubuntu-14.04}
+          simplexmlpackagename = 'php-xml'
+        end
         pp = <<-EOS
         class{'php':
           extensions => {
@@ -48,7 +56,7 @@ describe 'php with default settings' do
               },
             }
             'simplexml'  => {
-              package_name => 'php-xml'
+              package_name => simplexmlpackagename,
             }
           }
         }

--- a/spec/acceptance/php_spec.rb
+++ b/spec/acceptance/php_spec.rb
@@ -34,7 +34,7 @@ describe 'php with default settings' do
   end
   context 'default parameters with extensions' do
     case default[:platform]
-    when %r{ubuntu-18.04}, %r{ubuntu-16.04}, %r{ubuntu-14.04}
+    when %r{ubuntu-18.04}, %r{ubuntu-16.04}
       it 'works with defaults' do
         case default[:platform]
         when %r{ubuntu-18.04}

--- a/spec/acceptance/php_spec.rb
+++ b/spec/acceptance/php_spec.rb
@@ -41,8 +41,6 @@ describe 'php with default settings' do
           simplexmlpackagename = 'php7.2-xml'
         when %r{ubuntu-16.04}
           simplexmlpackagename = 'php7.0-xml'
-        when %r{ubuntu-14.04}
-          simplexmlpackagename = 'php-xml'
         end
         pp = <<-EOS
         class{'php':
@@ -57,6 +55,26 @@ describe 'php with default settings' do
             },
             'simplexml'  => {
               package_name => '#{simplexmlpackagename}',
+            }
+          }
+        }
+        EOS
+        # Run it twice and test for idempotency
+        apply_manifest(pp, catch_failures: true)
+        apply_manifest(pp, catch_changes: true)
+      end
+    when %r{ubuntu-14.04}
+      it 'works with defaults' do
+        pp = <<-EOS
+        class{'php':
+          extensions => {
+            'mysql'    => {},
+            'gd'       => {},
+            'net-url'  => {
+              package_prefix => 'php-',
+              settings       => {
+                extension => undef
+              },
             }
           }
         }

--- a/spec/acceptance/php_spec.rb
+++ b/spec/acceptance/php_spec.rb
@@ -12,10 +12,13 @@ describe 'php with default settings' do
     case default[:platform]
     when %r{ubuntu-18.04}
       packagename = 'php7.2-fpm'
+      simplexmlpackagename = 'php7.2-xml'
     when %r{ubuntu-16.04}
       packagename = 'php7.0-fpm'
+      simplexmlpackagename = 'php0.2-xml'
     when %r{ubuntu-14.04}
       packagename = 'php5-fpm'
+      simplexmlpackagename = 'php5-xml'
     when %r{el}
       packagename = 'php-fpm'
     when %r{debian-8}
@@ -45,7 +48,9 @@ describe 'php with default settings' do
               package_prefix => 'php-',
               settings       => {
                 extension => undef
-              }
+              },
+            'simplexml'  => {
+              package_name => simplexmlpackagename
             }
           }
         }

--- a/spec/acceptance/php_spec.rb
+++ b/spec/acceptance/php_spec.rb
@@ -12,13 +12,10 @@ describe 'php with default settings' do
     case default[:platform]
     when %r{ubuntu-18.04}
       packagename = 'php7.2-fpm'
-      simplexmlpackagename = 'php7.2-xml'
     when %r{ubuntu-16.04}
       packagename = 'php7.0-fpm'
-      simplexmlpackagename = 'php0.2-xml'
     when %r{ubuntu-14.04}
       packagename = 'php5-fpm'
-      simplexmlpackagename = 'php5-xml'
     when %r{el}
       packagename = 'php-fpm'
     when %r{debian-8}
@@ -50,7 +47,7 @@ describe 'php with default settings' do
                 extension => undef
               },
             'simplexml'  => {
-              package_name => simplexmlpackagename
+              package_name => 'php-xml'
             }
           }
         }


### PR DESCRIPTION
#### Pull Request (PR) description
Fix eternal reload for mysqli and simplexml extension. 

Package name for mysqli extension is php7.2-mysql. Package name for simlexml extension is php7.2-xml. I can use package_prefix variable, than i add package_name variable with higher priority.

Example of configuration:
```puppet
class { '::php':
        ensure       => latest,
        manage_repos => false,
        pear         => true,
        composer     => false,
        fpm          => false,
        dev          => false,
        extensions   => {
            bcmath    => {},
            curl      => {},
            gd        => {},
            mbstring  => {},
            simplexml => {
                package_name => 'php7.2-xml',
            },
            mysqli    => {
                package_name => 'php7.2-mysql',
            },
            sqlite3   => {},
        },
    }
```

#### This Pull Request (PR) fixes the following issues
Fixes #309 
Fixes #497 
