### PR TITLE
Fix version handling for remi repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,6 +156,22 @@ matrix:
     env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=debian8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     script: bundle exec rspec spec/acceptance/php_spec.rb
     services: docker
+  # Remi repo, relevant for Red Hat family only
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    script: bundle exec rspec spec/acceptance/php_remi_spec.rb
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    script: bundle exec rspec spec/acceptance/php_remi_spec.rb
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    script: bundle exec rspec spec/acceptance/php_remi_spec.rb
+    services: docker
 branches:
   only:
   - master

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :system_tests do
   gem 'beaker-puppet',                      :require => false
   gem 'beaker-puppet_install_helper',       :require => false
   gem 'beaker-module_install_helper',       :require => false
+  gem 'beaker-vagrant',                     :require => false
   gem 'rbnacl', '>= 4',                     :require => false
   gem 'rbnacl-libsodium',                   :require => false
   gem 'bcrypt_pbkdf',                       :require => false

--- a/README.md
+++ b/README.md
@@ -399,6 +399,33 @@ A list of commonly used modules:
     }
 ```
 
+### RedHat/CentOS using the remi repo
+
+On Red Hat-based systems you can also install PHP using the
+[remi repo](https://rpms.remirepo.net).
+
+Class example:
+
+```puppet
+class { 'php':
+  ...
+  manage_repos: true,
+}
+class { 'php::globals':
+  php_version => '7.3',
+  rhscl_mode  => 'remi',
+}
+```
+
+Hiera example:
+
+```yaml
+---
+php::manage_repos: true
+php::globals::php_version: '7.3'
+php::globals::rhscl_mode: 'remi'
+```
+
 ### Facts
 
 We deliver a `phpversion` fact with this module. This is explicitly **NOT** intended

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -1,5 +1,8 @@
 # PHP globals class
 #
+# PHP support status can be found here:
+# https://secure.php.net/supported-versions.php
+#
 # === Parameters
 #
 # [*php_version*]
@@ -36,10 +39,13 @@ class php::globals (
       '16.04' => '7.0',
       default => '5.x',
     },
-    default => '5.x',
+    # This needs to be a valid version number due to remi repo on RHEL/CentOS
+    # Eventually these should all be valid version numbers by default
+    default => '5.6',
   }
 
-  $globals_php_version = pick($php_version, $default_php_version)
+  $globals_php_version       = pick($php_version, $default_php_version)
+  $globals_php_version_nodot = $globals_php_version.delete('.')
 
   case $facts['os']['family'] {
     'Debian': {
@@ -118,11 +124,13 @@ class php::globals (
     'RedHat': {
       case $rhscl_mode {
         'remi': {
-          $rhscl_root             = "/opt/remi/${php_version}/root"
-          $default_config_root    = "/etc/opt/remi/${php_version}"
-          $default_fpm_pid_file   = '/var/run/php-fpm/php-fpm.pid'
-          $package_prefix         = "${php_version}-php-"
-          $fpm_service_name       = "${php_version}-php-fpm"
+          # Using this installation method requires a sane version number
+          assert_type(Pattern[/^\d\.\d$/], $globals_php_version)
+          $rhscl_root           = "/opt/remi/php${globals_php_version_nodot}/root"
+          $default_config_root  = "/etc/opt/remi/php${globals_php_version_nodot}"
+          $default_fpm_pid_file = '/var/run/php-fpm/php-fpm.pid'
+          $package_prefix       = "php${globals_php_version_nodot}-php-"
+          $fpm_service_name     = "php${globals_php_version_nodot}-php-fpm"
         }
         'rhscl': {
           $rhscl_root             = "/opt/rh/${php_version}/root"

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -2,15 +2,16 @@
 #
 # === Parameters
 #
-# [*yum_repo*]
-#   Class name of the repo under ::yum::repo
+# [*version*]
+#   Dotted PHP version. Default: $php::globals::globals_php_version
 #
 
 class php::repo::redhat (
-  $yum_repo = 'remi_php56',
+  Pattern[/^\d\.\d$/] $version = $php::globals::globals_php_version,
 ) {
 
-  $releasever = $facts['os']['name'] ? {
+  $version_nodot = $version.delete('.')
+  $releasever    = $facts['os']['name'] ? {
     /(?i:Amazon)/ => '6',
     default       => '$releasever',  # Yum var
   }
@@ -24,9 +25,9 @@ class php::repo::redhat (
     priority   => 1,
   }
 
-  yumrepo { 'remi-php56':
-    descr      => 'Remi\'s PHP 5.6 RPM repository for Enterprise Linux $releasever - $basearch',
-    mirrorlist => "https://rpms.remirepo.net/enterprise/${releasever}/php56/mirror",
+  yumrepo { "remi-php${version_nodot}":
+    descr      => "Remi's PHP ${version} RPM repository for Enterprise Linux \$releasever - \$basearch",
+    mirrorlist => "https://rpms.remirepo.net/enterprise/${releasever}/php${version_nodot}/mirror",
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => 'https://rpms.remirepo.net/RPM-GPG-KEY-remi',

--- a/spec/acceptance/php_remi_spec.rb
+++ b/spec/acceptance/php_remi_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper_acceptance'
+
+describe 'php with remi repo' do
+  context 'default parameters' do
+    it 'works with defaults' do
+      pp = <<-EOS
+      class { 'php::globals':
+        rhscl_mode => 'remi',
+      }
+      -> class { 'php':
+        manage_repos => true,
+      }
+      EOS
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    packagename = 'php56-php-fpm'
+    describe package(packagename) do
+      it { is_expected.to be_installed }
+    end
+
+    describe service(packagename) do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+  end
+end

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -229,12 +229,13 @@ describe 'php', type: :class do
 
         describe 'when called with global option for rhscl_mode' do
           describe 'when called with mode "remi"' do
-            scl_php_version = 'php56'
+            scl_php_version = '5.6'
+            scl_php_version_nodot = scl_php_version.delete('.')
             rhscl_mode = 'remi'
             let(:pre_condition) do
-              "class {'::php::globals':
-                        php_version => '#{scl_php_version}',
-                        rhscl_mode => '#{rhscl_mode}'
+              "class { 'php::globals':
+                php_version => '#{scl_php_version}',
+                rhscl_mode  => '#{rhscl_mode}',
               }"
             end
             let(:params) do
@@ -242,13 +243,13 @@ describe 'php', type: :class do
             end
 
             it { is_expected.to contain_class('php::global') }
-            it { is_expected.to contain_package("#{scl_php_version}-php-cli").with_ensure('present') }
-            it { is_expected.to contain_package("#{scl_php_version}-php-common").with_ensure('present') }
-            it { is_expected.to contain_php__config('global').with(file: "/etc/opt/#{rhscl_mode}/#{scl_php_version}/php.ini") }
+            it { is_expected.to contain_package("php#{scl_php_version_nodot}-php-cli").with_ensure('present') }
+            it { is_expected.to contain_package("php#{scl_php_version_nodot}-php-common").with_ensure('present') }
+            it { is_expected.to contain_php__config('global').with(file: "/etc/opt/#{rhscl_mode}/php#{scl_php_version_nodot}/php.ini") }
             it { is_expected.not_to contain_php__config('cli') }
 
             # see: https://github.com/voxpupuli/puppet-php/blob/master/lib/puppet/parser/functions/to_hash_settings.rb
-            it { is_expected.to contain_php__config__setting("/etc/opt/#{rhscl_mode}/#{scl_php_version}/php.ini: Date/date.timezone").with_value('Europe/Berlin') }
+            it { is_expected.to contain_php__config__setting("/etc/opt/#{rhscl_mode}/php#{scl_php_version_nodot}/php.ini: Date/date.timezone").with_value('Europe/Berlin') }
           end
 
           describe 'when called with mode "rhscl"' do

--- a/spec/defines/extension_rhscl_spec.rb
+++ b/spec/defines/extension_rhscl_spec.rb
@@ -10,23 +10,24 @@ describe 'php::extension' do
       end
 
       describe 'with rhscl_mode "remi" enabled: install one extension' do
-        scl_php_version = 'php56'
+        scl_php_version = '5.6'
+        scl_php_version_nodot = scl_php_version.delete('.')
         rhscl_mode = 'remi'
-        configs_root = "/etc/opt/#{rhscl_mode}/#{scl_php_version}"
+        configs_root = "/etc/opt/#{rhscl_mode}/php#{scl_php_version_nodot}"
 
         let(:pre_condition) do
-          "class {'::php::globals':
-                    php_version => '#{scl_php_version}',
-                    rhscl_mode => '#{rhscl_mode}'
-          }->
-          class {'::php':
-                   ensure         => installed,
-                   manage_repos   => false,
-                   fpm            => false,
-                   dev            => true, # must be true since we are using the provider => pecl (option installs header files)
-                   composer       => false,
-                   pear           => true,
-                   phpunit        => false,
+          "class { 'php::globals':
+            php_version => '#{scl_php_version}',
+            rhscl_mode  => '#{rhscl_mode}',
+          }
+          -> class { 'php':
+            ensure       => installed,
+            manage_repos => false,
+            fpm          => false,
+            dev          => true, # must be true since we are using the provider => pecl (option installs header files)
+            composer     => false,
+            pear         => true,
+            phpunit      => false,
           }"
         end
 


### PR DESCRIPTION
#### Pull Request (PR) description

- Cleans up and fixes version handling when installing PHP using the remi repo on CentOS/RHEL. Tested on CentOS 7.
- Also adds `beaker-vagrant` to gemfile (see details in commit message for why)

Note: This changes the default version string of `$php::globals::globals_php_version` from `5.x` to `5.6` on non-Debian/Ubuntu because we really should use sane version strings in such variables so we can re-use them elsewhere (like in `php::repo::redhat` for remi repo). I anticipate the versioning in `php::globals` will be cleaned up eventually. (I'll volunteer too.) It doesn't look like this change will have any adverse effects.

If merged, this PR obsoletes the following PRs: (Sorry, I'm impatient and they don't look like they're going anywhere)
- https://github.com/voxpupuli/puppet-php/pull/495
- https://github.com/voxpupuli/puppet-php/pull/509

#### This Pull Request (PR) fixes the following issues
Fixes #480
