### PR TITLE
Adding the option to set process.dumpable

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -67,6 +67,10 @@
 # [*template*]
 #   The template to use for the pool
 #
+# [*process.dumpable*]
+#   Allow PHP to create a coredump during a segfault. Must still set
+#   rlimit_core
+#
 # [*rlimit_files*]
 #
 # [*rlimit_core*]
@@ -144,6 +148,7 @@ define php::fpm::pool (
   $security_limit_extensions               = undef,
   $slowlog                                 = "/var/log/php-fpm/${name}-slow.log",
   $template                                = 'php/fpm/pool.conf.erb',
+  $process_dumpable                        = false,
   $rlimit_files                            = undef,
   $rlimit_core                             = undef,
   $chroot                                  = undef,
@@ -166,6 +171,12 @@ define php::fpm::pool (
   # The base class must be included first because it is used by parameter defaults
   if ! defined(Class['php']) {
     warning('You must include the php base class before using any php defined resources')
+  }
+
+  if ($php::globals::php_version != undef) {
+    $php_version_major = regsubst($php::globals::php_version, '^(\d+)\.(\d+)$','\1')
+  } else {
+    $php_version_major = 5
   }
 
   $pool = $title

--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -72,6 +72,18 @@ group = <%= @group_final %>
 ; Note: This value is mandatory.
 pm = <%= @pm %>
 
+<% if @php_version_major.to_i >= 7 -%>
+; Set the process dumpable flag (PR_SET_DUMPABLE prctl) even if the process user
+; or group is differrent than the master process user. It allows to create process
+; core dump and ptrace the process for the pool user.
+; Default Value: no
+<%   if @process_dumpable -%>
+process.dumpable = yes
+<%   else -%>
+process.dumpable = no
+<%   end -%>
+<% end -%>
+
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes to be created when pm is set to 'dynamic'.
 ; This value sets the limit on the number of simultaneous requests that will be


### PR DESCRIPTION

#### Pull Request (PR) description
Adding the option to set process.dumpable

#### This Pull Request (PR) fixes the following issues
If `process.dumpable` is disabled core dumps cannot be captured on segfaults even if `rlimit_core` is set because of the following change to PHP:

https://github.com/php/php-src/commit/276d19feaa43e6f77eeac59fc9e2639bee4d116b#diff-10cc4db817271640849c40a7fc1f0569
