### PR TITLE
add pool_purge option to php init.pp

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -49,6 +49,10 @@
 #   Hash of defaults params php::fpm::pool resources that will be created.
 #   Defaults is empty hash.
 #
+# [*pool_purge*]
+#   Whether to purge pool config files not created
+#   by this module
+#
 class php::fpm (
   String $ensure                = $php::ensure,
   $user                         = $php::fpm_user,
@@ -64,6 +68,7 @@ class php::fpm (
   Hash $pools                   = $php::real_fpm_pools,
   $log_owner                    = $php::log_owner,
   $log_group                    = $php::log_group,
+  $pool_purge                   = $php::pool_purge,
 ) {
 
   if ! defined(Class['php']) {
@@ -85,13 +90,14 @@ class php::fpm (
   }
 
   class { 'php::fpm::config':
-    user      => $user,
-    group     => $group,
-    inifile   => $inifile,
-    settings  => $real_settings,
-    log_owner => $log_owner,
-    log_group => $log_group,
-    require   => Package[$real_package],
+    user       => $user,
+    group      => $group,
+    inifile    => $inifile,
+    settings   => $real_settings,
+    log_owner  => $log_owner,
+    log_group  => $log_group,
+    require    => Package[$real_package],
+    pool_purge => $pool_purge,
   }
 
   contain 'php::fpm::config'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,6 +123,10 @@
 #   For example, 'PHP/memory_limit' => '1000M' sets memory_limit to 1000M
 #   for the PHP cli ini file, regardless of the values from $settings.
 #
+# [*pool_purge*]
+#   Whether to purge pool config files not created
+#   by this module
+#
 class php (
   String $ensure                                  = $php::params::ensure,
   Boolean $manage_repos                           = $php::params::manage_repos,
@@ -157,6 +161,7 @@ class php (
   Boolean $ext_tool_enabled                       = $php::params::ext_tool_enabled,
   String $log_owner                               = $php::params::fpm_user,
   String $log_group                               = $php::params::fpm_group,
+  Boolean $pool_purge                             = $php::params::pool_purge,
 ) inherits php::params {
 
   $real_fpm_package = pick($fpm_package, "${package_prefix}${::php::params::fpm_package_suffix}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class php::params inherits php::globals {
   $phpunit_source      = 'https://phar.phpunit.de/phpunit.phar'
   $phpunit_path        = '/usr/local/bin/phpunit'
   $phpunit_max_age     = 30
+  $pool_purge          = false
 
   case $facts['os']['family'] {
     'Debian': {


### PR DESCRIPTION
#### Pull Request (PR) description
It currently appears to be very difficult to set pool_purge. I suppose it is possible by setting fpm => false and including classes manually but this seems like a much cleaner option which is in-line with how other settings are done in the package.