### PR TITLE
Do not manage mysql.ini when using Ubuntu repo (and fix CI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,17 +38,17 @@ matrix:
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1404-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1804-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     script: bundle exec rspec spec/acceptance/php56_spec.rb
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu1404-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu1804-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     script: bundle exec rspec spec/acceptance/php56_spec.rb
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=ubuntu1404-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=ubuntu1804-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     script: bundle exec rspec spec/acceptance/php56_spec.rb
     services: docker
   - rvm: 2.5.3
@@ -94,21 +94,6 @@ matrix:
   - rvm: 2.5.3
     bundler_args: --without development release
     env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=ubuntu1604-64 BEAKER_HYPERVISOR=docker CHECK=beaker
-    script: bundle exec rspec spec/acceptance/php_spec.rb
-    services: docker
-  - rvm: 2.5.3
-    bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1404-64 BEAKER_HYPERVISOR=docker CHECK=beaker
-    script: bundle exec rspec spec/acceptance/php_spec.rb
-    services: docker
-  - rvm: 2.5.3
-    bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu1404-64 BEAKER_HYPERVISOR=docker CHECK=beaker
-    script: bundle exec rspec spec/acceptance/php_spec.rb
-    services: docker
-  - rvm: 2.5.3
-    bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=ubuntu1404-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     script: bundle exec rspec spec/acceptance/php_spec.rb
     services: docker
   - rvm: 2.5.3

--- a/manifests/extension/config.pp
+++ b/manifests/extension/config.pp
@@ -89,8 +89,16 @@ define php::extension::config (
     $final_settings = $full_settings
   }
 
+  if $facts['os']['name'] == 'Ubuntu' and $zend != true and $name == 'mysql' {
+    # Do not manage the .ini file if it's mysql.  PHP 7.0+ do not have
+    # mysql.so.  If mysql.ini exists and version is 7.0+, then remove it.
+    $real_ensure = 'absent'
+  } else {
+    $real_ensure = $ensure
+  }
+
   $config_root_ini = pick_default($php::config_root_ini, $php::params::config_root_ini)
-  if $ensure != 'absent' {
+  if $real_ensure != 'absent' {
     ::php::config { $title:
       file   => "${config_root_ini}/${ini_prefix}${ini_name}.ini",
       config => $final_settings,

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
         "16.04",
         "18.04"
       ]

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -187,7 +187,7 @@ describe 'php::extension' do
           it { is_expected.to contain_php__config('xdebug').with_config('zend_extension' => '/usr/lib/php5/20100525/xdebug.so') }
         end
 
-        case facts[:osfamily]
+        case facts[:os]['name']
         when 'Debian'
           context 'on Debian' do
             let(:title) { 'xdebug' }
@@ -220,6 +220,21 @@ describe 'php::extension' do
                     'test'      => 'foo'
                   }
                 )
+              end
+            end
+          end
+        when 'Ubuntu'
+          context 'on Ubuntu' do
+            context 'do not setup mysql.ini' do
+              let(:title) { 'mysql' }
+              let(:params) do
+                {
+                  name: 'mysql'
+                }
+              end
+
+              it do
+                is_expected.to contain_file("#{etcdir}/mysql.ini").with(ensure: 'absent')
               end
             end
           end


### PR DESCRIPTION
#### Pull Request (PR) description

PHP 7.0+ packaged with Ubuntu does not ship with mysql.so, and enabling the module should not setup a mysql.ini file referring to it.

This is an adaptation of #330 which has been stale for some times…

#### This Pull Request (PR) fixes the following issues
Fixes #330 