### PR TITLE
Fix deprecated Hiera lookup warnings. Add default www pool in YAML.

### DIFF
--- a/data/default.yaml
+++ b/data/default.yaml
@@ -1,0 +1,13 @@
+---
+php::fpm_pools:
+  www:
+    catch_workers_output: 'no'
+    listen: '127.0.0.1:9000'
+    listen_backlog: '-1'
+    pm: dynamic
+    pm_max_children: 50
+    pm_max_requests: 0
+    pm_max_spare_servers: 35
+    pm_min_spare_servers: 5
+    pm_start_servers: 5
+    request_terminate_timeout: 0

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,6 @@
+---
+version: 5
+hierarchy:
+  - name: default.yaml
+    paths:
+      - 'default.yaml'

--- a/manifests/apache_config.pp
+++ b/manifests/apache_config.pp
@@ -15,7 +15,7 @@ class php::apache_config(
 
   assert_private()
 
-  $real_settings = deep_merge($settings, hiera_hash('php::apache::settings', {}))
+  $real_settings = $real_settings = lookup('php::apache::settings', Hash, {'strategy' => 'deep', 'merge_hash_arrays' => true}, $settings)
 
   php::config { 'apache':
     file   => $inifile,

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -33,7 +33,7 @@ class php::cli(
     }
   }
 
-  $real_settings = deep_merge($settings, hiera_hash('php::cli::settings', {}))
+  $real_settings = lookup('php::cli::settings', Hash, {'strategy' => 'deep', 'merge_hash_arrays' => true}, $settings)
 
   if $inifile != $php::params::config_root_inifile {
     # only create a cli specific inifile if the filenames are different

--- a/manifests/embedded.pp
+++ b/manifests/embedded.pp
@@ -23,9 +23,13 @@ class php::embedded(
 
   assert_private()
 
-  $real_settings = deep_merge(
-    $settings,
-    hiera_hash('php::embedded::settings', {})
+  $real_settings = lookup(
+    'php::embedded::settings',
+    Hash, {
+      'strategy' => 'deep',
+      'merge_hash_arrays' => true
+    },
+    $settings
   )
 
   $real_package = $facts['os']['family'] ? {

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -70,7 +70,7 @@ class php::fpm (
     warning('php::fpm is private')
   }
 
-  $real_settings = deep_merge($settings, hiera_hash('php::fpm::settings', {}))
+  $real_settings = lookup('php::fpm::settings', Hash, {'strategy' => 'deep', 'merge_hash_arrays' => true}, $settings)
 
   # On FreeBSD fpm is not a separate package, but included in the 'php' package.
   # Implies that the option SET+=FPM was set when building the port.
@@ -99,8 +99,8 @@ class php::fpm (
 
   Class['php::fpm::config'] ~> Class['php::fpm::service']
 
-  $real_global_pool_settings = hiera_hash('php::fpm::global_pool_settings', $global_pool_settings)
-  $real_pools = hiera_hash('php::fpm::pools', $pools)
+  $real_global_pool_settings = lookup('php::fpm::global_pool_settings', Hash, {'strategy' => 'unique'}, $global_pool_settings)
+  $real_pools = lookup('php::fpm::pools', Hash, {'strategy' => 'unique'}, $pools)
   create_resources(::php::fpm::pool, $real_pools, $real_global_pool_settings)
 
   # Create an override to use a reload signal as trusty and utopic's

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,7 +131,7 @@ class php (
   $fpm_service_ensure                             = $php::params::fpm_service_ensure,
   $fpm_service_name                               = $php::params::fpm_service_name,
   $fpm_service_provider                           = undef,
-  Hash $fpm_pools                                 = { 'www' => {} },
+  Hash $fpm_pools                                 = {},
   Hash $fpm_global_pool_settings                  = {},
   $fpm_inifile                                    = $php::params::fpm_inifile,
   $fpm_package                                    = undef,


### PR DESCRIPTION
Fix deprecated Hiera lookup warnings. Add YAML structure for default www pool so it can be overridden as needed.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
1. Fix depreciated Hiera lookup warnings by replacing hiera_hash functionality with deep_merge lookups.
2. Added 'hiera.conf' and 'data/default.yaml' to populate the default FPM 'www' pool with defaults, that can be overridden elsewhere in Hiera.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Use format:
Fixes #449 
Complements #288 
Complements #160 
-->
