### PR TITLE
Add apparmor_hat support to php::fpm::pool

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2248,6 +2248,9 @@ documented here: http://php.net/manual/en/install.fpm.configuration.php.
 [*group*]
   The group that php-fpm should run as
 
+[*apparmor_hat*]
+  The Apparmor hat to use
+
 [*pm*]
 
 [*pm_max_children*]

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -130,7 +130,7 @@ define php::fpm::pool (
   $listen_mode                             = undef,
   $user                                    = $php::fpm::config::user,
   $group                                   = $php::fpm::config::group,
-  $apparmor_hat                            = undef,
+  Optional[String] $apparmor_hat           = undef,
   $pm                                      = 'dynamic',
   $pm_max_children                         = '50',
   $pm_start_servers                        = '5',

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -130,7 +130,7 @@ define php::fpm::pool (
   $listen_mode                             = undef,
   $user                                    = $php::fpm::config::user,
   $group                                   = $php::fpm::config::group,
-  Optional[String] $apparmor_hat           = undef,
+  Optional[String[1]] $apparmor_hat        = undef,
   $pm                                      = 'dynamic',
   $pm_max_children                         = '50',
   $pm_start_servers                        = '5',

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -30,6 +30,9 @@
 # [*group*]
 #   The group that php-fpm should run as
 #
+# [*apparmor_hat*]
+#   The Apparmor hat to use
+#
 # [*pm*]
 #
 # [*pm_max_children*]
@@ -127,6 +130,7 @@ define php::fpm::pool (
   $listen_mode                             = undef,
   $user                                    = $php::fpm::config::user,
   $group                                   = $php::fpm::config::group,
+  $apparmor_hat                            = undef,
   $pm                                      = 'dynamic',
   $pm_max_children                         = '50',
   $pm_start_servers                        = '5',

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -239,6 +239,46 @@ describe 'php', type: :class do
         it { is_expected.to contain_file(dstfile).with_content(%r{group = nginx}) }
       end
 
+      describe 'when configured with a pool with apparmor_hat parameter' do
+        let(:params) { { fpm_pools: { 'www' => { 'apparmor_hat' => 'www' } } } }
+
+        it { is_expected.to contain_php__fpm__pool('www').with(apparmor_hat: 'www') }
+
+        dstfile = case facts[:osfamily]
+                  when 'Debian'
+                    case facts[:os]['name']
+                    when 'Debian'
+                      case facts[:os]['release']['major']
+                      when '10'
+                        '/etc/php/7.3/fpm/pool.d/www.conf'
+                      when '9'
+                        '/etc/php/7.0/fpm/pool.d/www.conf'
+                      else
+                        '/etc/php5/fpm/pool.d/www.conf'
+                      end
+                    when 'Ubuntu'
+                      case facts[:os]['release']['major']
+                      when '18.04'
+                        '/etc/php/7.2/fpm/pool.d/www.conf'
+                      when '16.04'
+                        '/etc/php/7.0/fpm/pool.d/www.conf'
+                      else
+                        '/etc/php5/fpm/pool.d/www.conf'
+                      end
+                    end
+                  when 'Archlinux'
+                    '/etc/php/php-fpm.d/www.conf'
+                  when 'Suse'
+                    '/etc/php5/fpm/pool.d/www.conf'
+                  when 'RedHat'
+                    '/etc/php-fpm.d/www.conf'
+                  when 'FreeBSD'
+                    '/usr/local/etc/php-fpm.d/www.conf'
+                  end
+
+        it { is_expected.to contain_file(dstfile).with_content(%r{apparmor_hat = www}) }
+      end
+
       describe 'when fpm is disabled' do
         let(:params) { { fpm: false } }
 

--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -46,6 +46,10 @@ listen.mode = <%= @listen_mode %>
 user = <%= @user %>
 ; RPM: Keep a group allowed to write in log dir.
 group = <%= @group_final %>
+<% if @apparmor_hat -%>
+; Apparmor hat to change to
+apparmor_hat = <%= @apparmor_hat %>
+<% end -%>
 
 ; Choose how the process manager will control the number of child processes.
 ; Possible Values:


### PR DESCRIPTION
#### Pull Request (PR) description

Add support for apparmor_hat directive. This allows a php-fpm binary contained by an Apparmor profile to switch to a more specific profile (`hat` in apparmor parlance) tailored to the FPM pool serving the request.

Here is an example of Apparmor profile including a hat called 'foo' for the pool serving a WordPress instance:

```
# Author: Simon Deziel
# vim:syntax=apparmor
#include <tunables/global>

/usr/sbin/php-fpm7.2 {
  #include <abstractions/base>
  #include <abstractions/nameservice>
  #include <abstractions/php>

  capability chown,
  capability dac_override,
  capability kill,
  capability setuid,
  capability setgid,
  capability sys_chroot,

  # slowlog
  capability sys_ptrace,
  ptrace (trace) peer=/usr/sbin/php-fpm7.2//*,

  /etc/php/7.2/fpm/php-fpm.conf  r,
  /etc/php/7.2/fpm/pool.d/*.conf r,
  /etc/ssl/openssl.cnf r,
  /usr/sbin/php-fpm7.2 rmix,

  owner /var/log/php7.2-fpm.log w,
  owner /var/log/php-fpm/*.log.slow rw,
  /run/php/php7.2-fpm.pid w,
  /run/systemd/notify w,

  # Unix sockets
  /run/php/*.sock rw,

  # XXX: weird that php7.2-fpm tests writing to /
  deny / rw,

  # aa_change_hat
  @{PROC}/@{pids}/attr/current rw,
  signal (send) set=(cont,quit,kill,term) peer=/usr/sbin/php-fpm7.2//*,
  change_profile /usr/sbin/php-fpm7.2 -> /usr/sbin/php-fpm7.2//*,
  # hats
  ^foo {
    #include <abstractions/base>
    #include <abstractions/nameservice>
    #include <abstractions/php>

    signal (receive) set=(cont,kill,quit,term) peer=/usr/sbin/php-fpm7.2,

    /usr/sbin/php-fpm7.2 mr,

    /var/log/php-fpm/foo-slow.log w,

    # Unix sockets
    /run/php/foo-fpm.sock rw,
    /run/mysqld/mysqld.sock rw,

    audit deny /var/www/foo/**.php w,
    /var/www/foo/** r,
    owner /var/www/foo/wp-content/** w,
  }
}
```

The php-fpm config would contain this:

```
# /etc/php/7.2/fpm/pool.d/foo.conf
[foo]
...
; Apparmor hat to change to
apparmor_hat = foo
```


*Note*: the above profile was tested on Ubuntu 18.04 with php-fpm from the Ubuntu repos. This version is compiled with Apparmor hat support which might not be the case for every distros.