### PR TITLE
Remove require php::dev when Ubuntu 14.04

### DIFF
--- a/manifests/extension/install.pp
+++ b/manifests/extension/install.pp
@@ -61,10 +61,15 @@ define php::extension::install (
         Package[$compiler_packages] -> Package[$real_package]
       }
 
-      $package_require      = [
-        Class['::php::pear'],
-        Class['::php::dev'],
-      ]
+      if $facts['os']['name'] == 'Ubuntu' and
+      versioncmp($facts['os']['release']['full'], '14.04') == 0  {
+        $package_require = Class['::php::pear']
+      } else {
+        $package_require      = [
+          Class['::php::pear'],
+          Class['::php::dev'],
+        ]
+      }
     }
 
     'none' : {


### PR DESCRIPTION
When using Ubuntu 14.04 there is no such package as php-dev

This commits remove the need of php::dev for extensions when running on
Ubuntu 14.04

TODO: create spec tests for this scenario