### PR TITLE
New Key for sury Repository

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -76,7 +76,7 @@ class php::repo::debian(
         'deb' => true,
       },
       key      => {
-        id     => 'DF3D585DB8F0EB658690A554AC0E47584A7A714D',
+        id     => '15058500A0235D97F5D10063B188E2B695BD4743',
         source => 'https://packages.sury.org/php/apt.gpg',
       },
     }


### PR DESCRIPTION
#### Pull Request (PR) description
The sury repository has a new gpg key. Therefore it should be updated.

#### This Pull Request (PR) fixes the following issues
apt-get update fails because the key is unknown.