### PR TITLE
set default version for debian buster and add support for buster

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -28,7 +28,8 @@ class php::globals (
 
   $default_php_version = $facts['os']['name'] ? {
     'Debian' => $facts['os']['release']['major'] ? {
-      '9' => '7.0',
+      '9'     => '7.0',
+      '10'    => '7.3',
       default => '5.x',
     },
     'Ubuntu' => $facts['os']['release']['major'] ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,7 @@ class php::params inherits php::globals {
 
       case $facts['os']['name'] {
         'Debian': {
-          $manage_repos = (versioncmp($facts['os']['release']['major'], '8') < 0)
+          $manage_repos = false
         }
 
         'Ubuntu': {

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {

--- a/spec/acceptance/php_spec.rb
+++ b/spec/acceptance/php_spec.rb
@@ -22,6 +22,8 @@ describe 'php with default settings' do
       packagename = 'php5-fpm'
     when %r{debian-9}
       packagename = 'php7.0-fpm'
+    when %r{debian-10}
+      packagename = 'php7.3-fpm'
     end
     describe package(packagename) do
       it { is_expected.to be_installed }
@@ -112,6 +114,8 @@ describe 'php with default settings' do
       packagename = 'php5-fpm'
     when %r{debian-9}
       packagename = 'php7.0-fpm'
+    when %r{debian-10}
+      packagename = 'php7.3-fpm'
     end
     describe package(packagename) do
       it { is_expected.to be_installed }

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -10,6 +10,8 @@ describe 'php', type: :class do
       php_cli_package = case facts[:os]['name']
                         when 'Debian'
                           case facts[:os]['release']['major']
+                          when '10'
+                            'php7.3-cli'
                           when '9'
                             'php7.0-cli'
                           else
@@ -28,6 +30,8 @@ describe 'php', type: :class do
       php_fpm_package = case facts[:os]['name']
                         when 'Debian'
                           case facts[:os]['release']['major']
+                          when '10'
+                            'php7.3-fpm'
                           when '9'
                             'php7.0-fpm'
                           else
@@ -46,6 +50,8 @@ describe 'php', type: :class do
       php_dev_package = case facts[:os]['name']
                         when 'Debian'
                           case facts[:os]['release']['major']
+                          when '10'
+                            'php7.3-dev'
                           when '9'
                             'php7.0-dev'
                           else
@@ -161,6 +167,8 @@ describe 'php', type: :class do
                     case facts[:os]['name']
                     when 'Debian'
                       case facts[:os]['release']['major']
+                      when '10'
+                        '/etc/php/7.3/fpm/pool.d/www.conf'
                       when '9'
                         '/etc/php/7.0/fpm/pool.d/www.conf'
                       else
@@ -199,6 +207,8 @@ describe 'php', type: :class do
                     case facts[:os]['name']
                     when 'Debian'
                       case facts[:os]['release']['major']
+                      when '10'
+                        '/etc/php/7.3/fpm/pool.d/www.conf'
                       when '9'
                         '/etc/php/7.0/fpm/pool.d/www.conf'
                       else

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -12,6 +12,8 @@ describe 'php::extension' do
         etcdir =  case facts[:os]['name']
                   when 'Debian'
                     case facts[:os]['release']['major']
+                    when '10'
+                      '/etc/php/7.3/mods-available'
                     when '9'
                       '/etc/php/7.0/mods-available'
                     else

--- a/spec/defines/fpm_pool_spec.rb
+++ b/spec/defines/fpm_pool_spec.rb
@@ -15,6 +15,8 @@ describe 'php::fpm::pool' do
           let(:params) { {} }
 
           case facts[:os]['release']['major']
+          when '10'
+            it { is_expected.to contain_file('/etc/php/7.3/fpm/pool.d/unique-name.conf') }
           when '9'
             it { is_expected.to contain_file('/etc/php/7.0/fpm/pool.d/unique-name.conf') }
           else


### PR DESCRIPTION
debian buster was released on july 6th and many folks are already
deploying it. This module should start supporting the new debian stable
version.

For this, we need the module to know what the new default PHP version is
for this new release.

Closes: #529

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
