### PR TITLE
fix "cannot redefine $real_settings" error

### DIFF
--- a/manifests/apache_config.pp
+++ b/manifests/apache_config.pp
@@ -15,7 +15,7 @@ class php::apache_config(
 
   assert_private()
 
-  $real_settings = $real_settings = lookup('php::apache::settings', Hash, {'strategy' => 'deep', 'merge_hash_arrays' => true}, $settings)
+  $real_settings = lookup('php::apache::settings', Hash, {'strategy' => 'deep', 'merge_hash_arrays' => true}, $settings)
 
   php::config { 'apache':
     file   => $inifile,


### PR DESCRIPTION

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Trying to use the apache_config class to apply settings to the apache
SAPI fails with an error caused by a duplicate variable definition:

```
Error while evaluating a Resource Statement, Evaluation Error: Cannot reassign variable '$real_settings' (file:
/etc/puppetlabs/code/environments/development/modules/php/manifests/apache_config.pp, line: 18, column: 18)
```

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
