### PR TITLE
Do a `deep` merge on `fpm` lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,23 @@ php::fpm::pools:
 
 ## Notes
 
+### Inheriting configuration across mutliple Hiera sources
+
+Configuration from Hiera such as `php::fpm::pools` is automatically
+lookup up using the "first" merge method. This means that the first
+value found is used. If you instead want to merge the hash keys
+across multiple Hiera sources, you can use [`lookup_options`] to set
+[`hash` or `deep` behaviors] such as:
+
+```yaml
+lookup_options:
+  php::fpm::pools:
+    merge: hash
+```
+
+[`lookup_options`]: https://puppet.com/docs/puppet/6.4/hiera_merging.html#concept-2997
+[`hash` or `deep` behaviors]: https://puppet.com/docs/puppet/6.4/hiera_merging.html#merge-behaviors
+
 ### Debian squeeze & Ubuntu precise come with PHP 5.3
 
 On Debian-based systems, we use `php5enmod` to enable extension-specific

--- a/README.md
+++ b/README.md
@@ -245,8 +245,9 @@ php::fpm::pools:
 Configuration from Hiera such as `php::fpm::pools` is automatically
 lookup up using the "first" merge method. This means that the first
 value found is used. If you instead want to merge the hash keys
-across multiple Hiera sources, you can use [`lookup_options`] to set
-[`hash` or `deep` behaviors] such as:
+across multiple Hiera sources, you can use [`lookup_options`] to
+set [`hash` or `deep` behaviors] such as in the example
+[data/default.yaml](data/default.yaml):
 
 ```yaml
 lookup_options:

--- a/data/default.yaml
+++ b/data/default.yaml
@@ -2,7 +2,7 @@
 
 lookup_options:
   php::fpm::pools:
-    merge: hash
+    merge: first
 
 php::fpm::pools:
   www:

--- a/data/default.yaml
+++ b/data/default.yaml
@@ -1,4 +1,9 @@
 ---
+
+lookup_options:
+  php::fpm::pools:
+    merge: hash
+
 php::fpm::pools:
   www:
     catch_workers_output: 'no'

--- a/data/default.yaml
+++ b/data/default.yaml
@@ -1,5 +1,5 @@
 ---
-php::fpm_pools:
+php::fpm::pools:
   www:
     catch_workers_output: 'no'
     listen: '127.0.0.1:9000'

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -70,7 +70,7 @@ class php::fpm (
     warning('php::fpm is private')
   }
 
-  $real_settings = lookup('php::fpm::settings', Hash, {'strategy' => 'deep', 'merge_hash_arrays' => true}, $settings)
+  $real_settings = $settings
 
   # On FreeBSD fpm is not a separate package, but included in the 'php' package.
   # Implies that the option SET+=FPM was set when building the port.
@@ -99,8 +99,8 @@ class php::fpm (
 
   Class['php::fpm::config'] ~> Class['php::fpm::service']
 
-  $real_global_pool_settings = lookup('php::fpm::global_pool_settings', Hash, {'strategy' => 'unique'}, $global_pool_settings)
-  $real_pools = lookup('php::fpm::pools', Hash, {'strategy' => 'unique'}, $pools)
+  $real_global_pool_settings = $global_pool_settings
+  $real_pools = $pools
   create_resources(::php::fpm::pool, $real_pools, $real_global_pool_settings)
 
   # Create an override to use a reload signal as trusty and utopic's


### PR DESCRIPTION
#### Pull Request (PR) description
When allowing configuring `php::fpm::pools` as hashes in Hiera, the `unique` ("array merge") behavior is currently used. [Documentation](https://puppet.com/docs/puppet/6.4/function.html#merge-behaviors) states this will return a merged array even though we are interested in a hash. Instead of doing this manual lookup, we can switch to auto lookups.

#### This Pull Request (PR) fixes the following issues
Fixes #536