### PR TITLE
Improve package prefix selection on FreeBSD

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -144,6 +144,14 @@ class php::globals (
       }
     }
     'FreeBSD': {
+      case $globals_php_version {
+        /^(\d)\.(\d)$/: {
+          $package_prefix = "php${1}${2}-"
+        }
+        default: {
+          $package_prefix = 'php56-'
+        }
+      }
       $default_config_root  = '/usr/local/etc'
       $default_fpm_pid_file = '/var/run/php-fpm.pid'
       $fpm_service_name     = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -179,7 +179,7 @@ class php::params inherits php::globals {
       $fpm_group               = 'www'
       $embedded_package_suffix = 'embed'
       $embedded_inifile        = "${config_root}/php-embed.ini"
-      $package_prefix          = 'php56-'
+      $package_prefix          = $php::globals::package_prefix
       $compiler_packages       = ['gcc']
       $manage_repos            = false
       $root_group              = 'wheel'

--- a/manifests/pear.pp
+++ b/manifests/pear.pp
@@ -33,10 +33,6 @@ class php::pear (
           # even though others are called 'php5-fpm' or 'php5-dev'
           $package_name = "php-${php::params::pear_package_suffix}"
         }
-        'FreeBSD': {
-          # On FreeBSD the package name is just 'pear'.
-          $package_name = $php::params::pear_package_suffix
-        }
         default: {
           # This is the default for all other architectures
           $package_name = "${php::package_prefix}${php::params::pear_package_suffix}"


### PR DESCRIPTION
On FreeBSD, the package prefix is currently hardcoded to php56. This change modifies the default behaviour to use the prefix matching the selected php version (from globals) if defined.

This change should be fully compatible, since the default is to fallback to php56, and if a custom version is specified, the package prefix has to be manually configured to match this version anyway.

Futhermore, the pear package is now using a php prefix as well (since 2018-03-08), which is also fixed by this pull request.