### PR TITLE
Fix running apt update on Debian family

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -22,7 +22,7 @@ class php::packages (
   assert_private()
 
   $real_names = union($names, $names_to_prefix)
-  if $facts['os']['family'] == 'debian' {
+  if $facts['os']['family'] == 'Debian' {
     if $manage_repos {
       include ::apt
       Class['::apt::update'] -> Package[$real_names]


### PR DESCRIPTION
Fix os::family name for Debian.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Fix running apt update on Debian family.
Replace 'debian' by 'Debian' in family check in accordance with Facter family name constants: https://github.com/puppetlabs/facter/blob/2aa2d1cd6487f73fb8e311cf027dcf30c2166e28/lib/inc/facter/facts/os_family.hpp 

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
