### PR TITLE
Fix enabling of zend extensions

### DIFF
--- a/manifests/extension/config.pp
+++ b/manifests/extension/config.pp
@@ -112,19 +112,21 @@ define php::extension::config (
 
     if $facts['os']['family'] == 'Debian' and $ext_tool_enabled {
       $cmd = "${ext_tool_enable} -s ${sapi} ${so_name}"
+      $execname = "ext_tool_enable_${so_name}"
 
       $_sapi = $sapi? {
         'ALL' => 'cli',
         default => $sapi,
       }
-      if has_key($final_settings, 'extension') and $final_settings[extension] {
-        exec { $cmd:
+      if has_key($final_settings, $extension_key) and $final_settings[$extension_key] {
+        exec { $execname:
+          command => $cmd,
           onlyif  => "${ext_tool_query} -s ${_sapi} -m ${so_name} | /bin/grep 'No module matches ${so_name}'",
           require => ::Php::Config[$title],
         }
 
         if $php::fpm {
-          Package[$php::fpm::package] ~> Exec[$cmd]
+          Package[$php::fpm::package] ~> Exec[$execname]
         }
       }
     }

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -198,6 +198,7 @@ describe 'php::extension' do
                   zend: true
                 }
               end
+
               it { is_expected.to contain_exec('ext_tool_enable_xdebug') }
             end
           end

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -189,6 +189,20 @@ describe 'php::extension' do
           it { is_expected.to contain_php__config('xdebug').with_config('zend_extension' => '/usr/lib/php5/20100525/xdebug.so') }
         end
 
+        if facts[:os]['family'] == 'Debian'
+          context 'on Debian family' do
+            context 'zend extensions call ext_tool_enable' do
+              let(:title) { 'xdebug' }
+              let(:params) do
+                {
+                  zend: true
+                }
+              end
+              it { is_expected.to contain_exec('ext_tool_enable_xdebug') }
+            end
+          end
+        end
+
         case facts[:os]['name']
         when 'Debian'
           context 'on Debian' do


### PR DESCRIPTION
#### Pull Request (PR) description
Zend extensions are not enabled on Debian because `phpenmod` is not executed.  Same patch as stalled PR 498 with a test added.

#### This Pull Request (PR) fixes the following issues
n/a