### PR TITLE
Set mode for /var/log/php-fpm and /var/run/php-fpm

### DIFF
--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -113,8 +113,9 @@ class php::fpm::config(
 
   ensure_resource('file', ['/var/run/php-fpm/', '/var/log/php-fpm/'], {
     ensure => directory,
-    owner => $user,
-    group => $group,
+    owner  => $user,
+    group  => $group,
+    mode   => '0755',
   })
 
   file { $pool_base_dir:

--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -97,30 +97,31 @@ class php::fpm::config(
 
   assert_private()
 
-  # Hack-ish to default to user for group too
-  $log_group_final = $log_group ? {
-    undef   => $log_owner,
-    default => $log_group,
-  }
-
   file { $config_file:
     ensure  => file,
     content => template('php/fpm/php-fpm.conf.erb'),
-    owner   => root,
+    owner   => 'root',
     group   => $root_group,
     mode    => '0644',
   }
 
-  ensure_resource('file', ['/var/run/php-fpm/', '/var/log/php-fpm/'], {
+  ensure_resource('file', '/var/run/php-fpm', {
     ensure => directory,
-    owner  => $user,
-    group  => $group,
+    owner  => 'root',
+    group  => $root_group,
     mode   => '0755',
+  })
+
+  ensure_resource('file', '/var/log/php-fpm/', {
+    ensure => directory,
+    owner  => 'root',
+    group  => $root_group,
+    mode   => $log_dir_mode,
   })
 
   file { $pool_base_dir:
     ensure => directory,
-    owner  => root,
+    owner  => 'root',
     group  => $root_group,
     mode   => '0755',
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Actively set mode on directories /var/log/php-fpm and /var/run/php-fpm.

To prevent the following error from logroate, amongst other things:
```
error: skipping "/var/log/php-fpm/error.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
```


#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
