### PR TITLE
Cleanup fpm config class

### DIFF
--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -97,29 +97,31 @@ class php::fpm::config(
 
   assert_private()
 
-  # Hack-ish to default to user for group too
-  $log_group_final = $log_group ? {
-    undef   => $log_owner,
-    default => $log_group,
-  }
-
   file { $config_file:
     ensure  => file,
     content => template('php/fpm/php-fpm.conf.erb'),
-    owner   => root,
+    owner   => 'root',
     group   => $root_group,
     mode    => '0644',
   }
 
-  ensure_resource('file', ['/var/run/php-fpm/', '/var/log/php-fpm/'], {
+  ensure_resource('file', '/var/run/php-fpm', {
     ensure => directory,
-    owner => $user,
-    group => $group,
+    owner  => 'root',
+    group  => $root_group,
+    mode   => '0755',
+  })
+
+  ensure_resource('file', '/var/log/php-fpm/', {
+    ensure => directory,
+    owner  => 'root',
+    group  => $root_group,
+    mode   => $log_dir_mode,
   })
 
   file { $pool_base_dir:
     ensure => directory,
-    owner  => root,
+    owner  => 'root',
     group  => $root_group,
     mode   => '0755',
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This pull request cleans up the fpm config class:
- Remove unused variable 'log_group_final'
- Fixes owner, group and mode for the directories '/var/log/php-fpm' and '/var/run/php-fpm'

/var/log/php-fpm:
We don't know which processes want to access this directory - therefore root with mode 0755 is used here. This is also the default within most distributions.

/var/run/php-fpm:
There is no need to set the PHP-FPM user/group as a owner of this directory. This is also follows the default within most distributions.

#### This Pull Request (PR) fixes the following issues
Fixes #568