### PR TITLE
add ability to define composer update channel

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -497,6 +497,9 @@ Install composer package manager
 [*path*]
   Holds path to the Composer executable
 
+[*channel*]
+  Holds the Update channel (stable|preview|snapshot|1|2)
+
 [*proxy_type*]
    proxy server type (none|http|https|ftp)
 

--- a/manifests/composer.pp
+++ b/manifests/composer.pp
@@ -8,6 +8,9 @@
 # [*path*]
 #   Holds path to the Composer executable
 #
+# [*channel*]
+#   Holds the Update channel (stable|preview|snapshot|1|2)
+#
 # [*proxy_type*]
 #    proxy server type (none|http|https|ftp)
 #
@@ -28,6 +31,7 @@ class php::composer (
   Stdlib::Absolutepath $path           = $php::params::composer_path,
   $proxy_type                          = undef,
   $proxy_server                        = undef,
+  Php::ComposerChannel $channel        = 'stable',
   Boolean $auto_update                 = true,
   Integer $max_age                     = $php::params::composer_max_age,
   Variant[Integer, String] $root_group = $php::params::root_group,
@@ -52,6 +56,7 @@ class php::composer (
       max_age      => $max_age,
       source       => $source,
       path         => $path,
+      channel      => $channel,
       proxy_type   => $proxy_type,
       proxy_server => $proxy_server,
     }

--- a/manifests/composer/auto_update.pp
+++ b/manifests/composer/auto_update.pp
@@ -11,6 +11,9 @@
 # [*path*]
 #   Holds path to the Composer executable
 #
+# [*channel*]
+#   Holds the Update channel (stable|preview|snapshot|1|2)
+#
 # [*proxy_type*]
 #    proxy server type (none|http|https|ftp)
 #
@@ -29,8 +32,9 @@ class php::composer::auto_update (
   $max_age,
   $source,
   $path,
-  $proxy_type   = undef,
-  $proxy_server = undef,
+  Php::ComposerChannel  $channel = 'stable',
+  $proxy_type                    = undef,
+  $proxy_server                  = undef,
 ) {
 
   assert_private()
@@ -44,7 +48,7 @@ class php::composer::auto_update (
 
   exec { 'update composer':
     # touch binary when an update is attempted to update its mtime for idempotency when no update is available
-    command     => "${path} --no-interaction --quiet self-update; touch ${path}",
+    command     => "${path} --no-interaction --quiet self-update --${channel}; touch ${path}",
     environment => $env,
     onlyif      => "test `find '${path}' -mtime +${max_age}`",
     path        => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/', '/usr/local/bin', '/usr/local/sbin' ],

--- a/types/composerchannel.pp
+++ b/types/composerchannel.pp
@@ -1,0 +1,7 @@
+type Php::ComposerChannel = Enum[
+  'stable',
+  'preview',
+  'snapshot',
+  '1',
+  '2' # lint:ignore:trailing_comma
+]


### PR DESCRIPTION
#### Pull Request (PR) description

Yesterday, composer released 2.0 snapshot.
So with current default behaviour, if i only set

`class { '::php::composer':
    max_age => 2,
}`

every composer installation is updated to version 2.0 snapshot.

So one solution is to set the 'source' to 'https://getcomposer.org/composer-stable.phar' initialy if i dont have it installed or use the param from this PR for updates, which then defaults update channel to 'stable'