### PR TITLE
(#596) drop 'reload' in favour of 'restart'

### DIFF
--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -24,14 +24,11 @@ class php::fpm::service (
     warning('php::fpm::service is private')
   }
 
-  $restart = "service ${service_name} reload"
-
   service { $service_name:
     ensure     => $ensure,
     enable     => $enable,
     provider   => $provider,
     hasrestart => true,
-    restart    => $restart,
     hasstatus  => true,
   }
 


### PR DESCRIPTION
#### Pull Request (PR) description

Some configuration options (e.g. 'listen_owner', 'listen_group', 'listen_mode', and maybe some more) do not apply by reloading 'php-fpm.service' but require a proper restart.


#### This Pull Request (PR) fixes the following issues

Fixes #596