### PR TITLE
php-fpm: Make service reload/restart configurable

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -53,22 +53,29 @@
 #   Whether to purge pool config files not created
 #   by this module
 #
+# [*reload_fpm_on_config_changes*]
+#   by default, we reload the service on changes.
+#   But certain options, like socket owner, will only be applied during a restart.
+#   If set to false, a restart will be executed instead of a reload.
+#   This default will be changed in a future release.
+#
 class php::fpm (
-  String $ensure                = $php::ensure,
-  $user                         = $php::fpm_user,
-  $group                        = $php::fpm_group,
-  $service_ensure               = $php::fpm_service_ensure,
-  $service_enable               = $php::fpm_service_enable,
-  $service_name                 = $php::fpm_service_name,
-  $service_provider             = $php::fpm_service_provider,
-  String $package               = $php::real_fpm_package,
-  Stdlib::Absolutepath $inifile = $php::fpm_inifile,
-  Hash $settings                = $php::real_settings,
-  $global_pool_settings         = $php::real_fpm_global_pool_settings,
-  Hash $pools                   = $php::real_fpm_pools,
-  $log_owner                    = $php::log_owner,
-  $log_group                    = $php::log_group,
-  Boolean $pool_purge           = $php::pool_purge,
+  String $ensure                        = $php::ensure,
+  $user                                 = $php::fpm_user,
+  $group                                = $php::fpm_group,
+  $service_ensure                       = $php::fpm_service_ensure,
+  $service_enable                       = $php::fpm_service_enable,
+  $service_name                         = $php::fpm_service_name,
+  $service_provider                     = $php::fpm_service_provider,
+  String $package                       = $php::real_fpm_package,
+  Stdlib::Absolutepath $inifile         = $php::fpm_inifile,
+  Hash $settings                        = $php::real_settings,
+  $global_pool_settings                 = $php::real_fpm_global_pool_settings,
+  Hash $pools                           = $php::real_fpm_pools,
+  $log_owner                            = $php::log_owner,
+  $log_group                            = $php::log_group,
+  Boolean $pool_purge                   = $php::pool_purge,
+  Boolean $reload_fpm_on_config_changes = $php::reload_fpm_on_config_changes,
 ) {
   if ! defined(Class['php']) {
     warning('php::fpm is private')

--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -14,21 +14,34 @@
 # [*provider*]
 #   Defines if the service provider to use
 #
+# [*reload_fpm_on_config_changes*]
+#   by default, we reload the service on changes.
+#   But certain options, like socket owner, will only be applied during a restart.
+#   If set to false, a restart will be executed instead of a reload.
+#   This default will be changed in a future release.
+#
 class php::fpm::service (
-  $service_name = $php::fpm::service_name,
-  $ensure       = $php::fpm::service_ensure,
-  $enable       = $php::fpm::service_enable,
-  $provider     = $php::fpm::service_provider,
+  $service_name                         = $php::fpm::service_name,
+  $ensure                               = $php::fpm::service_ensure,
+  $enable                               = $php::fpm::service_enable,
+  $provider                             = $php::fpm::service_provider,
+  Boolean $reload_fpm_on_config_changes = $php::fpm::reload_fpm_on_config_changes,
 ) {
   if ! defined(Class['php::fpm']) {
     warning('php::fpm::service is private')
   }
 
+  if $reload_fpm_on_config_changes {
+    $restart = "service ${service_name} reload"
+  } else {
+    $restart = undef
+  }
   service { $service_name:
     ensure     => $ensure,
     enable     => $enable,
     provider   => $provider,
     hasrestart => true,
+    restart    => $restart,
     hasstatus  => true,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,6 +127,12 @@
 #   Whether to purge pool config files not created
 #   by this module
 #
+# [*reload_fpm_on_config_changes*]
+#   by default, we reload the service on changes.
+#   But certain options, like socket owner, will only be applied during a restart.
+#   If set to false, a restart will be executed instead of a reload.
+#   This default will be changed in a future release.
+#
 class php (
   String $ensure                                  = $php::params::ensure,
   Boolean $manage_repos                           = $php::params::manage_repos,
@@ -162,6 +168,7 @@ class php (
   String $log_owner                               = $php::params::fpm_user,
   String $log_group                               = $php::params::fpm_group,
   Boolean $pool_purge                             = $php::params::pool_purge,
+  Boolean $reload_fpm_on_config_changes           = true,
 ) inherits php::params {
   $real_fpm_package = pick($fpm_package, "${package_prefix}${php::params::fpm_package_suffix}")
 


### PR DESCRIPTION
By default, this module uses a reload for the php-fpm service. This is
nice because it ensures that there is no downtime. But this is also bad
because certain configuration options, like unix socket owner/group will
only be changed during a restart.

Fixes: https://github.com/voxpupuli/puppet-php/issues/596
Replaces: https://github.com/voxpupuli/puppet-php/pull/597

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
