### PR TITLE
php::globals: support Ubuntu 20.04 that ships php 7.4

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -7,6 +7,9 @@
     - set: centos7-64
       options:
         script: 'bundle exec rspec spec/acceptance/php56_spec.rb'
+    - set: ubuntu2004-64
+      options:
+        script: 'bundle exec rspec spec/acceptance/php_spec.rb'
     - set: ubuntu1804-64
       options:
         script: 'bundle exec rspec spec/acceptance/php_spec.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,11 @@ jobs:
       services: docker
     - rvm: 2.5.3
       bundler_args: --without development release
+      env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=ubuntu2004-64 CHECK=beaker
+      script: bundle exec rspec spec/acceptance/php_spec.rb
+      services: docker
+    - rvm: 2.5.3
+      bundler_args: --without development release
       env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=ubuntu1804-64 CHECK=beaker
       script: bundle exec rspec spec/acceptance/php_spec.rb
       services: docker

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -31,6 +31,7 @@ class php::globals (
       default => '7.3',
     },
     'Ubuntu' => $facts['os']['release']['major'] ? {
+      '20.04' => '7.4',
       '16.04' => '7.0',
       default => '7.2',
     },

--- a/metadata.json
+++ b/metadata.json
@@ -41,7 +41,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     },
     {

--- a/spec/acceptance/php_spec.rb
+++ b/spec/acceptance/php_spec.rb
@@ -10,6 +10,8 @@ describe 'php with default settings' do
     end
 
     case default[:platform]
+    when %r{ubuntu-20.04}
+      packagename = 'php7.4-fpm'
     when %r{ubuntu-18.04}
       packagename = 'php7.2-fpm'
     when %r{ubuntu-16.04}
@@ -34,9 +36,11 @@ describe 'php with default settings' do
   end
   context 'default parameters with extensions' do
     case default[:platform]
-    when %r{ubuntu-18.04}, %r{ubuntu-16.04}
+    when %r{ubuntu-20.04}, %r{ubuntu-18.04}, %r{ubuntu-16.04}
       it 'works with defaults' do
         case default[:platform]
+        when %r{ubuntu-20.04}
+          simplexmlpackagename = 'php7.4-xml'
         when %r{ubuntu-18.04}
           simplexmlpackagename = 'php7.2-xml'
         when %r{ubuntu-16.04}
@@ -80,6 +84,8 @@ describe 'php with default settings' do
     end
 
     case default[:platform]
+    when %r{ubuntu-20.04}
+      packagename = 'php7.4-fpm'
     when %r{ubuntu-18.04}
       packagename = 'php7.2-fpm'
     when %r{ubuntu-16.04}

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -19,6 +19,8 @@ describe 'php', type: :class do
                           end
                         when 'Ubuntu'
                           case facts[:os]['release']['major']
+                          when '20.04'
+                            'php7.4-cli'
                           when '18.04'
                             'php7.2-cli'
                           when '16.04'
@@ -39,6 +41,8 @@ describe 'php', type: :class do
                           end
                         when 'Ubuntu'
                           case facts[:os]['release']['major']
+                          when '20.04'
+                            'php7.4-fpm'
                           when '18.04'
                             'php7.2-fpm'
                           when '16.04'
@@ -59,6 +63,8 @@ describe 'php', type: :class do
                           end
                         when 'Ubuntu'
                           case facts[:os]['release']['major']
+                          when '20.04'
+                            'php7.4-dev'
                           when '18.04'
                             'php7.2-dev'
                           when '16.04'
@@ -178,6 +184,8 @@ describe 'php', type: :class do
                       end
                     when 'Ubuntu'
                       case facts[:os]['release']['major']
+                      when '20.04'
+                        '/etc/php/7.4/fpm/pool.d/www.conf'
                       when '18.04'
                         '/etc/php/7.2/fpm/pool.d/www.conf'
                       when '16.04'
@@ -218,6 +226,8 @@ describe 'php', type: :class do
                       end
                     when 'Ubuntu'
                       case facts[:os]['release']['major']
+                      when '20.04'
+                        '/etc/php/7.4/fpm/pool.d/www.conf'
                       when '18.04'
                         '/etc/php/7.2/fpm/pool.d/www.conf'
                       when '16.04'
@@ -258,6 +268,8 @@ describe 'php', type: :class do
                       end
                     when 'Ubuntu'
                       case facts[:os]['release']['major']
+                      when '20.04'
+                        '/etc/php/7.4/fpm/pool.d/www.conf'
                       when '18.04'
                         '/etc/php/7.2/fpm/pool.d/www.conf'
                       when '16.04'

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -21,6 +21,8 @@ describe 'php::extension' do
                     end
                   when 'Ubuntu'
                     case facts[:os]['release']['major']
+                    when '20.04'
+                      '/etc/php/7.4/mods-available'
                     when '18.04'
                       '/etc/php/7.2/mods-available'
                     when '16.04'

--- a/spec/defines/fpm_pool_spec.rb
+++ b/spec/defines/fpm_pool_spec.rb
@@ -29,6 +29,8 @@ describe 'php::fpm::pool' do
           let(:params) { {} }
 
           case facts[:os]['release']['major']
+          when '20.04'
+            it { is_expected.to contain_file('/etc/php/7.4/fpm/pool.d/unique-name.conf') }
           when '18.04'
             it { is_expected.to contain_file('/etc/php/7.2/fpm/pool.d/unique-name.conf') }
           when '16.04'


### PR DESCRIPTION
Replaces: #580