### PR TITLE
come current with upstream/master so we can bump stdlib

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -70,6 +70,10 @@
 # [*template*]
 #   The template to use for the pool
 #
+# [*process.dumpable*]
+#   Allow PHP to create a coredump during a segfault. Must still set
+#   rlimit_core
+#
 # [*rlimit_files*]
 #
 # [*rlimit_core*]
@@ -148,6 +152,7 @@ define php::fpm::pool (
   $security_limit_extensions               = undef,
   $slowlog                                 = "/var/log/php-fpm/${name}-slow.log",
   $template                                = 'php/fpm/pool.conf.erb',
+  $process_dumpable          = false,
   $rlimit_files                            = undef,
   $rlimit_core                             = undef,
   $chroot                                  = undef,

--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -76,6 +76,18 @@ apparmor_hat = <%= @apparmor_hat %>
 ; Note: This value is mandatory.
 pm = <%= @pm %>
 
+
+; Set the process dumpable flag (PR_SET_DUMPABLE prctl) even if the process user
+; or group is differrent than the master process user. It allows to create process
+; core dump and ptrace the process for the pool user.
+; Default Value: no
+<% if @process_dumpable -%>
+process.dumpable = yes
+<% else -%>
+process.dumpable = no
+<% end -%>
+
+
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes to be created when pm is set to 'dynamic'.
 ; This value sets the limit on the number of simultaneous requests that will be


### PR DESCRIPTION
## What/Why
We rely on @mhagstrand's addition to this module — https://github.com/bigcommerce/puppet-php/commit/36fe9f6988c72026265148177a8c4f06c403ee3f — which still has an open/un-merged upstream MR — https://github.com/voxpupuli/puppet-php/pull/511. In my effort to bump up our `puppetlabs-stdlib` version this change brings up up to the current `master` from https://github.com/voxpupuli/puppet-php and pulls in that change.

## Impact
This newer module version will not be used I merge this MR and update the ref in our `Puppetfile/Puppetfile.lock` files in our puppet repo

Since it's so long, I'll give some crib notes.... 