### PR TITLE
Allow empty string for setting value

### DIFF
--- a/manifests/config/setting.pp
+++ b/manifests/config/setting.pp
@@ -20,7 +20,7 @@
 #
 define php::config::setting (
   String[1] $key,
-  Variant[Integer, String[1]] $value,
+  Variant[Integer, String] $value,
   Stdlib::Absolutepath $file,
 ) {
   assert_private()


### PR DESCRIPTION
Some PHP features are enabled by default and can be disabled by using an empty string as a setting value, e.g. [user_ini.filename](https://www.php.net/manual/en/configuration.file.per-user.php).  The code currently require a non-empty string, making it impossible to disable such a feature.

Allow an empty string as the value of a setting.

Fix #639 
