### PR TITLE
Allow 0 for pm_start_servers

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -133,7 +133,7 @@ define php::fpm::pool (
   Optional[String[1]] $apparmor_hat        = undef,
   String[1] $pm                            = 'dynamic',
   Integer[1] $pm_max_children              = 50,
-  Integer[1] $pm_start_servers             = 5,
+  Integer[0] $pm_start_servers             = 5,
   Integer[0] $pm_min_spare_servers         = 5,
   Integer[0] $pm_max_spare_servers         = 35,
   Integer[0] $pm_max_requests              = 0,


### PR DESCRIPTION
pm_start_servers=0 is a supported setting, can be used for on demand services.