### PR TITLE
Fix static redhat remi repo v8.0.2

### DIFF
--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -25,7 +25,7 @@ class php::repo::redhat (
 
   yumrepo { $yum_repo:
     descr      => "Remi's ${yum_repo.match('php.+$')[0].strip} RPM repository for Enterprise Linux \$releasever - \$basearch",
-    mirrorlist => "https://rpms.remirepo.net/enterprise/$releasever/${yum_repo.match('php.+$')[0].strip}/mirror",
+    mirrorlist => "https://rpms.remirepo.net/enterprise/${releasever}/${yum_repo.match('php.+$')[0].strip}/mirror",
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => 'https://rpms.remirepo.net/RPM-GPG-KEY-remi',


### PR DESCRIPTION
Currently the class php::repo::redhat is hardcoded to create only the remi56 repo.   This request removes that static value and creates based on $yum_repo.   This allows for other versions such as remi_php72, etc..