### PR TITLE
Allow a setting to be undef to force absent.

### DIFF
--- a/manifests/config/setting.pp
+++ b/manifests/config/setting.pp
@@ -20,8 +20,8 @@
 #
 define php::config::setting (
   String[1] $key,
-  Variant[Integer, String] $value,
   Stdlib::Absolutepath $file,
+  Optional[Variant[Integer, String]] $value = undef,
 ) {
   assert_private()
 
@@ -35,13 +35,13 @@ define php::config::setting (
   }
 
   if $value == undef {
-    $ensure = 'absent'
+    $_ensure = 'absent'
   } else {
-    $ensure = 'present'
+    $_ensure = 'present'
   }
 
   ini_setting { $name:
-    ensure  => $ensure,
+    ensure  => $_ensure,
     value   => $value,
     path    => $file,
     section => $section,

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -292,6 +292,25 @@ describe 'php', type: :class do
       end
 
       if facts[:osfamily] == 'RedHat' || facts[:osfamily] == 'CentOS'
+        describe 'when called with valid settings parameter types' do
+          let(:params) do
+            {
+              'settings' =>
+              {
+                'PHP/memory_limit'          => '300M',
+                'PHP/safe_mode_include_dir' => :undef,
+                'PHP/error_reporting'       => '',
+                'PHP/max_execution_time'    => 60
+              }
+            }
+          end
+
+          it { is_expected.to contain_php__config__setting('/etc/php.ini: PHP/memory_limit').with_value('300M') }
+          it { is_expected.to contain_ini_setting('/etc/php.ini: PHP/safe_mode_include_dir').with_ensure('absent') }
+          it { is_expected.to contain_php__config__setting('/etc/php.ini: PHP/error_reporting').with_value('') }
+          it { is_expected.to contain_php__config__setting('/etc/php.ini: PHP/max_execution_time').with_value(60) }
+        end
+
         describe 'when called with cli_settings parameter' do
           let(:params) do
             {


### PR DESCRIPTION
#### Pull Request (PR) description
The code for `php::config::setting` permits passing `Undef` to force the `ini_setting` to be absent instead of present but the recent type change does not allow `Undef`.  This simply adds `Undef` as a valid type.
