### PR TITLE
Allow ::php::config::setting value to be "undef"

### DIFF
--- a/manifests/config/setting.pp
+++ b/manifests/config/setting.pp
@@ -20,7 +20,7 @@
 #
 define php::config::setting (
   String[1] $key,
-  Optional[Variant[Integer, String]] $value,
+  Variant[Integer, String, Undef] $value,
   Stdlib::Absolutepath $file,
 ) {
   assert_private()

--- a/manifests/config/setting.pp
+++ b/manifests/config/setting.pp
@@ -20,7 +20,7 @@
 #
 define php::config::setting (
   String[1] $key,
-  Variant[Integer, String] $value,
+  Optional[Variant[Integer, String]] $value,
   Stdlib::Absolutepath $file,
 ) {
   assert_private()


### PR DESCRIPTION
This is necessary so that config settings can be removed (at least as a workaround for #653).
