### PR TITLE
fix installing latest PHP on Debian

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -35,22 +35,22 @@ class php::repo::debian (
   Boolean $dotdeb         = true,
   Boolean $sury           = true,
 ) {
-  assert_private()
-
   include 'apt'
 
-  apt::source { "source_php_${release}":
-    location => $location,
-    release  => $release,
-    repos    => $repos,
-    include  => {
-      'src' => $include_src,
-      'deb' => true,
-    },
-    key      => $key,
+  if ($dotdeb) {
+    apt::source { "source_php_${release}":
+      location => $location,
+      release  => $release,
+      repos    => $repos,
+      include  => {
+        'src' => $include_src,
+        'deb' => true,
+      },
+      key      => $key,
+    }
   }
 
-  if ($sury and $php::globals::php_version in ['7.1','7.2']) {
+  if ($sury) {
     apt::source { 'source_php_sury':
       location => 'https://packages.sury.org/php/',
       repos    => 'main',

--- a/spec/classes/php_repo_debian_spec.rb
+++ b/spec/classes/php_repo_debian_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'php::repo::debian', type: :class do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      describe 'works without params' do
+        if facts[:os]['name'] == 'Debian'
+          it { is_expected.to compile.with_all_deps }
+          context 'dotdeb' do
+            let(:params) { { 'dotdeb' => true, 'sury' => false } }
+
+            it { is_expected.to contain_apt__source('source_php_wheezy-php56') }
+            it { is_expected.not_to contain_apt__source('source_php_sury') }
+          end
+          context 'sury' do
+            let(:params) { { 'dotdeb' => false, 'sury' => true } }
+
+            it { is_expected.not_to contain_apt__source('source_php_wheezy-php56') }
+            it { is_expected.to contain_apt__source('source_php_sury') }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
I tried installing PHP 7.4 on Debian bullseye, and ended up with package from dotdeb, with references to php 5.6, on Debian wheezy. Some parameters to the php::repo::debian class were just ignored, and the test on php_version being 7.1 or 7.2 seemed too restrictive to me. So I fixed the code so that it works for me, but please keep in mind that I'm by no means a Puppet expert, and even less so when it comes to PHP.
And this is my first Pull Request, so I hope I did not mess up.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
Fixes #458