### PR TITLE
(#458) Remove dotdeb and sury repos overuse on Debian

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -5,9 +5,6 @@
 # [*location*]
 #   Location of the apt repository
 #
-# [*release*]
-#   Release of the apt repository
-#
 # [*repos*]
 #   Apt repository names
 #
@@ -25,7 +22,6 @@
 #
 class php::repo::debian (
   String[1] $location     = 'https://packages.dotdeb.org',
-  String[1] $release      = 'wheezy-php56',
   String[1] $repos        = 'all',
   Boolean $include_src    = false,
   Hash $key               = {
@@ -37,20 +33,24 @@ class php::repo::debian (
 ) {
   assert_private()
 
+  if $facts['os']['name'] != 'Debian' {
+    fail("class php::repo::debian does not work on OS ${facts['os']['name']}")
+  }
   include 'apt'
 
-  apt::source { "source_php_${release}":
-    location => $location,
-    release  => $release,
-    repos    => $repos,
-    include  => {
-      'src' => $include_src,
-      'deb' => true,
-    },
-    key      => $key,
+  if ($dotdeb and $facts['os']['release']['major'] in ['6', '7', '8']) {
+    apt::source { 'source_php_dotdeb':
+      location => $location,
+      repos    => $repos,
+      include  => {
+        'src' => $include_src,
+        'deb' => true,
+      },
+      key      => $key,
+    }
   }
 
-  if ($sury and $php::globals::php_version in ['7.1','7.2']) {
+  if ($sury and $facts['os']['release']['major'] in ['9', '10', '11']) {
     apt::source { 'source_php_sury':
       location => 'https://packages.sury.org/php/',
       repos    => 'main',

--- a/spec/classes/php_repo_debian_spec.rb
+++ b/spec/classes/php_repo_debian_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'php::repo::debian', type: :class do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      before do
+        Puppet::Parser::Functions.newfunction(:my_assert_private, type: :rvalue) do |args|
+          # Fake assert_private function from stdlib to not fail within this test
+        end
+      end
+
+      describe 'works without params' do
+        let(:pre_condition) do
+          'function assert_private() { return my_assert_private() }'
+        end
+
+        if facts[:os]['name'] == 'Debian'
+          it { is_expected.to compile.with_all_deps }
+
+          case facts[:os]['release']['major']
+          when '6', '7', '8'
+            it { is_expected.to contain_apt__source('source_php_dotdeb') }
+            it { is_expected.not_to contain_apt__source('source_php_sury') }
+          when '9', '10', '11'
+            it { is_expected.not_to contain_apt__source('source_php_dotdeb') }
+            it { is_expected.to contain_apt__source('source_php_sury') }
+          end
+        else
+          it { is_expected.to compile.and_raise_error(%r{class php::repo::debian does not work on OS}) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
Remove dotdeb and sury repos overuse on Debian.
#436 looks like too far from readiness and probably we can use this PR now.
`assert_private()` was removed because tests couldn't run on private class and other php::repo classes aren't private also. Thank you!

#### This Pull Request (PR) fixes the following issues
Fixes #458 
