### PR TITLE
Add option to disable management of rundir

### DIFF
--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -93,7 +93,11 @@ class php::fpm::config (
   String[1] $root_group                                                 = $php::params::root_group,
   String $syslog_facility                                               = 'daemon',
   String $syslog_ident                                                  = 'php-fpm',
+<<<<<<< HEAD
   Boolean $manage_run_dir                                               = true
+=======
+  Boolean $manage_run_dir = true
+>>>>>>> 8ae9754 (Add option to disable management of rundir)
 ) inherits php::params {
   assert_private()
 

--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -93,7 +93,7 @@ class php::fpm::config (
   String[1] $root_group                                                 = $php::params::root_group,
   String $syslog_facility                                               = 'daemon',
   String $syslog_ident                                                  = 'php-fpm',
-  Boolean $manange_run_dir                                              = true
+  Boolean $manage_run_dir                                               = true
 ) inherits php::params {
   assert_private()
 
@@ -105,7 +105,7 @@ class php::fpm::config (
     mode    => '0644',
   }
 
-  if $manange_run_dir {
+  if $manage_run_dir {
     ensure_resource('file', '/var/run/php-fpm',
       {
         ensure => directory,

--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -93,11 +93,7 @@ class php::fpm::config (
   String[1] $root_group                                                 = $php::params::root_group,
   String $syslog_facility                                               = 'daemon',
   String $syslog_ident                                                  = 'php-fpm',
-<<<<<<< HEAD
   Boolean $manage_run_dir                                               = true
-=======
-  Boolean $manage_run_dir = true
->>>>>>> 8ae9754 (Add option to disable management of rundir)
 ) inherits php::params {
   assert_private()
 

--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -93,6 +93,7 @@ class php::fpm::config (
   String[1] $root_group                                                 = $php::params::root_group,
   String $syslog_facility                                               = 'daemon',
   String $syslog_ident                                                  = 'php-fpm',
+  Bool $manange_run_dir                                                 = true
 ) inherits php::params {
   assert_private()
 
@@ -104,15 +105,17 @@ class php::fpm::config (
     mode    => '0644',
   }
 
-  ensure_resource('file', '/var/run/php-fpm',
-    {
-      ensure => directory,
-      owner  => 'root',
-      group  => $root_group,
-      mode   => '0755',
-    }
-  )
-
+  if $manange_run_dir {
+    ensure_resource('file', '/var/run/php-fpm',
+      {
+        ensure => directory,
+        owner  => 'root',
+        group  => $root_group,
+        mode   => '0755',
+      }
+    )
+  }
+  
   ensure_resource('file', '/var/log/php-fpm/',
     {
       ensure => directory,

--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -106,14 +106,12 @@ class php::fpm::config (
   }
 
   if $manage_run_dir {
-    ensure_resource('file', '/var/run/php-fpm',
-      {
-        ensure => directory,
-        owner  => 'root',
-        group  => $root_group,
-        mode   => '0755',
-      }
-    )
+    file { '/var/run/php-fpm':
+      ensure => directory,
+      owner  => 'root',
+      group  => $root_group,
+      mode   => '0755',
+    }
   }
 
   ensure_resource('file', '/var/log/php-fpm/',

--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -93,7 +93,7 @@ class php::fpm::config (
   String[1] $root_group                                                 = $php::params::root_group,
   String $syslog_facility                                               = 'daemon',
   String $syslog_ident                                                  = 'php-fpm',
-  Bool $manange_run_dir                                                 = true
+  Boolean $manange_run_dir                                              = true
 ) inherits php::params {
   assert_private()
 
@@ -115,7 +115,7 @@ class php::fpm::config (
       }
     )
   }
-  
+
   ensure_resource('file', '/var/log/php-fpm/',
     {
       ensure => directory,


### PR DESCRIPTION
I am using php7.4 from sury on debian 10.
After every server reboot, this module creates the /var/run/php-fpm directory (which is not used by php-fpm) and triggers a reload, which resets all open connections to the php-fpm daemon.

This PR added an option to disable the managing of the /var/run/php-fpm directory