### PR TITLE
Allow unsupported environments

### DIFF
--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -15,10 +15,10 @@ class php::dev (
 ) inherits php::params {
   assert_private()
 
-  # On FreeBSD there is no 'devel' package.
-  $real_package = $facts['os']['family'] ? {
-    'FreeBSD' => [],
-    default   => $package,
+  # On FreeBSD, Arch there is no 'devel' package. If dev_package_suffix is undef, consider to not install.
+  $real_package = $php::params::dev_package_suffix ? {
+    undef   => [],
+    default => $package,
   }
 
   if $facts['os']['family'] == 'Debian' {

--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -32,7 +32,10 @@ class php::fpm::service (
   }
 
   if $reload_fpm_on_config_changes {
-    $restart = "service ${service_name} reload"
+    $restart = $facts['service_provider'] ? {
+      'systemd' => "systemctl reload ${service_name}",
+      undef     => "service ${service_name} reload"
+    }
   } else {
     $restart = undef
   }

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -23,21 +23,23 @@ class php::globals (
   Optional[Stdlib::Absolutepath] $fpm_pid_file  = undef,
   Optional[Enum['rhscl', 'remi']] $rhscl_mode   = undef,
 ) {
-  $default_php_version = $facts['os']['name'] ? {
-    'Debian' => $facts['os']['release']['major'] ? {
-      '10'    => '7.3',
-      '11'    => '7.4',
-      default => fail("Unsupported Debian release: ${fact('os.release.major')}"),
-    },
-    'Ubuntu' => $facts['os']['release']['major'] ? {
-      '18.04' => '7.2',
-      '20.04' => '7.4',
-      default => fail("Unsupported Ubuntu release: ${fact('os.release.major')}"),
-    },
-    default => '5.x',
+  if ($php_version == undef) {
+    $globals_php_version = $facts['os']['name'] ? {
+      'Debian' => $facts['os']['release']['major'] ? {
+        '10'    => '7.3',
+        '11'    => '7.4',
+        default => fail("Unsupported Debian release: ${fact('os.release.major')}"),
+      },
+      'Ubuntu' => $facts['os']['release']['major'] ? {
+        '18.04' => '7.2',
+        '20.04' => '7.4',
+        default => fail("Unsupported Ubuntu release: ${fact('os.release.major')}"),
+      },
+      default  => '5.x',
+    }
+  } else {
+    $globals_php_version = $php_version
   }
-
-  $globals_php_version = pick($php_version, $default_php_version)
 
   case $facts['os']['family'] {
     'Debian': {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -150,7 +150,7 @@ class php (
   Boolean $embedded                               = false,
   Boolean $dev                                    = true,
   Boolean $composer                               = true,
-  Boolean $pear                                   = true,
+  Boolean $pear                                   = $php::params::pear,
   String $pear_ensure                             = $php::params::pear_ensure,
   Boolean $phpunit                                = false,
   Boolean $apache_config                          = false,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,6 +56,7 @@ class php::params inherits php::globals {
       $ext_tool_enable         = $php::globals::ext_tool_enable
       $ext_tool_query          = $php::globals::ext_tool_query
       $ext_tool_enabled        = true
+      $pear                    = true
 
       case $facts['os']['name'] {
         'Debian': {
@@ -103,6 +104,8 @@ class php::params inherits php::globals {
       $ext_tool_enable         = undef
       $ext_tool_query          = undef
       $ext_tool_enabled        = false
+      $pear                    = true
+
       case $facts['os']['name'] {
         'SLES': {
           $compiler_packages = []
@@ -170,6 +173,7 @@ class php::params inherits php::globals {
       $ext_tool_enable         = undef
       $ext_tool_query          = undef
       $ext_tool_enabled        = false
+      $pear                    = true
     }
     'FreeBSD': {
       $config_root             = $php::globals::globals_config_root
@@ -200,6 +204,7 @@ class php::params inherits php::globals {
       $ext_tool_enable         = undef
       $ext_tool_query          = undef
       $ext_tool_enabled        = false
+      $pear                    = true
     }
     'Archlinux': {
       $config_root_ini         = '/etc/php/conf.d'
@@ -215,8 +220,8 @@ class php::params inherits php::globals {
       $fpm_package_suffix      = 'fpm'
       $fpm_pool_dir            = '/etc/php/php-fpm.d'
       $fpm_service_name        = 'php-fpm'
-      $fpm_user                = 'root'
-      $fpm_group               = 'root'
+      $fpm_user                = 'http'
+      $fpm_group               = 'http'
       $apache_inifile          = '/etc/php/php.ini'
       $embedded_package_suffix = 'embedded'
       $embedded_inifile        = '/etc/php/php.ini'
@@ -227,6 +232,7 @@ class php::params inherits php::globals {
       $ext_tool_enable         = undef
       $ext_tool_query          = undef
       $ext_tool_enabled        = false
+      $pear                    = false
     }
     default: {
       fail("Unsupported osfamily: ${facts['os']['family']}")

--- a/spec/acceptance/php_spec.rb
+++ b/spec/acceptance/php_spec.rb
@@ -11,16 +11,16 @@ describe 'php with default settings' do
       apply_manifest(pp, catch_changes: true)
     end
 
-    case default[:platform]
-    when %r{ubuntu-20.04}, %r{debian-11}
-      packagename = 'php7.4-fpm'
-    when %r{ubuntu-18.04}
-      packagename = 'php7.2-fpm'
-    when %r{el}
-      packagename = 'php-fpm'
-    when %r{debian-10}
-      packagename = 'php7.3-fpm'
-    end
+    packagename = case default[:platform]
+                  when %r{ubuntu-20.04}, %r{debian-11}
+                    'php7.4-fpm'
+                  when %r{ubuntu-18.04}
+                    'php7.2-fpm'
+                  when %r{debian-10}
+                    'php7.3-fpm'
+                  else
+                    'php-fpm'
+                  end
     describe package(packagename) do
       it { is_expected.to be_installed }
     end
@@ -42,9 +42,9 @@ describe 'php with default settings' do
           simplexmlpackagename = 'php7.2-xml'
         end
         pp = <<-EOS
-        class{'php':
+        class{ 'php':
           extensions => {
-            'mysql'    => {},
+            'intl'     => {},
             'gd'       => {},
             'net-url'  => {
               package_prefix => 'php-',
@@ -62,9 +62,9 @@ describe 'php with default settings' do
     else
       it 'works with defaults' do
         pp = <<-EOS
-        class{'php':
+        class{ 'php':
           extensions => {
-            'mysql'    => {},
+            'intl'     => {},
             'gd'       => {}
           }
         }
@@ -75,16 +75,16 @@ describe 'php with default settings' do
       end
     end
 
-    case default[:platform]
-    when %r{ubuntu-20.04}, %r{debian-11}
-      packagename = 'php7.4-fpm'
-    when %r{ubuntu-18.04}
-      packagename = 'php7.2-fpm'
-    when %r{el}
-      packagename = 'php-fpm'
-    when %r{debian-10}
-      packagename = 'php7.3-fpm'
-    end
+    packagename = case default[:platform]
+                  when %r{ubuntu-20.04}, %r{debian-11}
+                    'php7.4-fpm'
+                  when %r{ubuntu-18.04}
+                    'php7.2-fpm'
+                  when %r{debian-10}
+                    'php7.3-fpm'
+                  else
+                    'php-fpm'
+                  end
     describe package(packagename) do
       it { is_expected.to be_installed }
     end

--- a/spec/classes/php_fpm_service_spec.rb
+++ b/spec/classes/php_fpm_service_spec.rb
@@ -22,7 +22,8 @@ describe 'php::fpm::service', type: :class do
         it { is_expected.to contain_class('php::packages') }
         it { is_expected.to contain_class('php::globals') }
         it { is_expected.to contain_class('php::params') }
-        it { is_expected.to contain_class('php::pear') }
+
+        it { is_expected.to contain_class('php::pear') } if facts[:osfamily] != 'Archlinux'
       end
 
       describe 'when called with no parameters' do

--- a/spec/classes/php_fpm_service_spec.rb
+++ b/spec/classes/php_fpm_service_spec.rb
@@ -25,7 +25,7 @@ describe 'php::fpm::service', type: :class do
         it { is_expected.to contain_class('php::pear') }
       end
 
-      describe 'when called with no parameters' do # rubocop: disable RSpec/EmptyExampleGroup
+      describe 'when called with no parameters' do
         case facts[:osfamily]
         when 'Debian'
           case facts[:operatingsystemrelease]

--- a/spec/classes/php_repo_spec.rb
+++ b/spec/classes/php_repo_spec.rb
@@ -21,7 +21,7 @@ describe 'php::repo', type: :class do
         end
       end
 
-      describe 'when configuring a package repo' do # rubocop: disable RSpec/EmptyExampleGroup
+      describe 'when configuring a package repo' do
         case facts[:osfamily]
         when 'Debian'
           case facts[:operatingsystem]

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -73,7 +73,7 @@ describe 'php', type: :class do
         it { is_expected.to compile.with_all_deps }
       end
 
-      describe 'when called with no parameters' do # rubocop: disable RSpec/EmptyExampleGroup
+      describe 'when called with no parameters' do
         case facts[:osfamily]
         when 'Suse', 'RedHat', 'CentOS'
           it { is_expected.to contain_class('php::global') }
@@ -127,7 +127,7 @@ describe 'php', type: :class do
         end
       end
 
-      describe 'when called with package_prefix parameter' do # rubocop: disable RSpec/EmptyExampleGroup
+      describe 'when called with package_prefix parameter' do
         package_prefix = 'myphp-'
         let(:params) { { package_prefix: package_prefix } }
 

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'php::config' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do # rubocop:disable RSpec/EmptyExampleGroup
+    context "on #{os}" do
       let :facts do
         facts
       end

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -138,58 +138,64 @@ describe 'php::extension' do
           it { is_expected.to contain_php__config('xdebug').with_config('zend_extension' => 'xdebug.so') }
         end
 
-        context 'pecl extensions support so_name' do
-          let(:title) { 'zendopcache' }
-          let(:params) do
-            {
-              provider: 'pecl',
-              zend: true,
-              so_name: 'opcache'
-            }
-          end
-
-          it do
-            is_expected.to contain_php__config('zendopcache').with(
-              file: "#{etcdir}/opcache.ini",
-              config: {
-                'zend_extension' => 'opcache.so'
+        if facts[:os]['family'] != 'Archlinux'
+          context 'pecl extensions support so_name' do
+            let(:title) { 'zendopcache' }
+            let(:params) do
+              {
+                provider: 'pecl',
+                zend: true,
+                so_name: 'opcache'
               }
-            )
+            end
+
+            it do
+              is_expected.to contain_php__config('zendopcache').with(
+                file: "#{etcdir}/opcache.ini",
+                config: {
+                  'zend_extension' => 'opcache.so'
+                }
+              )
+            end
           end
         end
 
-        context 'add ini file prefix if requested' do
-          let(:title) { 'zendopcache' }
-          let(:params) do
-            {
-              provider: 'pecl',
-              zend: true,
-              ini_prefix: '10-',
-              so_name: 'opcache'
-            }
-          end
-
-          it do
-            is_expected.to contain_php__config('zendopcache').with(
-              file: "#{etcdir}/10-opcache.ini",
-              config: {
-                'zend_extension' => 'opcache.so'
+        if facts[:os]['family'] != 'Archlinux'
+          context 'add ini file prefix if requested' do
+            let(:title) { 'zendopcache' }
+            let(:params) do
+              {
+                provider: 'pecl',
+                zend: true,
+                ini_prefix: '10-',
+                so_name: 'opcache'
               }
-            )
+            end
+
+            it do
+              is_expected.to contain_php__config('zendopcache').with(
+                file: "#{etcdir}/10-opcache.ini",
+                config: {
+                  'zend_extension' => 'opcache.so'
+                }
+              )
+            end
           end
         end
 
-        context 'pecl extensions support php_api_version' do
-          let(:title) { 'xdebug' }
-          let(:params) do
-            {
-              provider: 'pecl',
-              zend: true,
-              php_api_version: '20100525'
-            }
-          end
+        if facts[:os]['family'] != 'Archlinux'
+          context 'pecl extensions support php_api_version' do
+            let(:title) { 'xdebug' }
+            let(:params) do
+              {
+                provider: 'pecl',
+                zend: true,
+                php_api_version: '20100525'
+              }
+            end
 
-          it { is_expected.to contain_php__config('xdebug').with_config('zend_extension' => '/usr/lib/php5/20100525/xdebug.so') }
+            it { is_expected.to contain_php__config('xdebug').with_config('zend_extension' => '/usr/lib/php5/20100525/xdebug.so') }
+          end
         end
 
         if facts[:os]['family'] == 'Debian'

--- a/spec/defines/fpm_pool_spec.rb
+++ b/spec/defines/fpm_pool_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'php::fpm::pool' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do # rubocop: disable RSpec/EmptyExampleGroup
+    context "on #{os}" do
       let :facts do
         facts
       end
@@ -12,7 +12,7 @@ describe 'php::fpm::pool' do
 
       case facts[:os]['name']
       when 'Debian'
-        context 'plain config' do # rubocop: disable RSpec/EmptyExampleGroup
+        context 'plain config' do
           let(:title) { 'unique-name' }
           let(:params) { {} }
 
@@ -26,7 +26,7 @@ describe 'php::fpm::pool' do
           end
         end
       when 'Ubuntu'
-        context 'plain config' do # rubocop: disable RSpec/EmptyExampleGroup
+        context 'plain config' do
           let(:title) { 'unique-name' }
           let(:params) { {} }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
This PR allow to use puppet-php on unsupported environments.

Administrators can define a global php version like `php::globals::php_version: 8.1`. If defined, the automatic version discovery based on OS version will be disabled.

My use case: I want to run/test this module in a Ubuntu 22.04 dev environment.

#### This Pull Request (PR) fixes the following issues