### PR TITLE
php-fpm: Reload service with systemd if available

### DIFF
--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -32,7 +32,10 @@ class php::fpm::service (
   }
 
   if $reload_fpm_on_config_changes {
-    $restart = "service ${service_name} reload"
+    $restart = $facts['service_provider'] ? {
+      'systemd' => "systemctl reload ${service_name}",
+      undef     => "service ${service_name} reload"
+    }
   } else {
     $restart = undef
   }

--- a/spec/classes/php_fpm_service_spec.rb
+++ b/spec/classes/php_fpm_service_spec.rb
@@ -25,7 +25,7 @@ describe 'php::fpm::service', type: :class do
         it { is_expected.to contain_class('php::pear') }
       end
 
-      describe 'when called with no parameters' do # rubocop: disable RSpec/EmptyExampleGroup
+      describe 'when called with no parameters' do
         case facts[:osfamily]
         when 'Debian'
           case facts[:operatingsystemrelease]

--- a/spec/classes/php_repo_spec.rb
+++ b/spec/classes/php_repo_spec.rb
@@ -21,7 +21,7 @@ describe 'php::repo', type: :class do
         end
       end
 
-      describe 'when configuring a package repo' do # rubocop: disable RSpec/EmptyExampleGroup
+      describe 'when configuring a package repo' do
         case facts[:osfamily]
         when 'Debian'
           case facts[:operatingsystem]

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -73,7 +73,7 @@ describe 'php', type: :class do
         it { is_expected.to compile.with_all_deps }
       end
 
-      describe 'when called with no parameters' do # rubocop: disable RSpec/EmptyExampleGroup
+      describe 'when called with no parameters' do
         case facts[:osfamily]
         when 'Suse', 'RedHat', 'CentOS'
           it { is_expected.to contain_class('php::global') }
@@ -127,7 +127,7 @@ describe 'php', type: :class do
         end
       end
 
-      describe 'when called with package_prefix parameter' do # rubocop: disable RSpec/EmptyExampleGroup
+      describe 'when called with package_prefix parameter' do
         package_prefix = 'myphp-'
         let(:params) { { package_prefix: package_prefix } }
 

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'php::config' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do # rubocop:disable RSpec/EmptyExampleGroup
+    context "on #{os}" do
       let :facts do
         facts
       end

--- a/spec/defines/fpm_pool_spec.rb
+++ b/spec/defines/fpm_pool_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'php::fpm::pool' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do # rubocop: disable RSpec/EmptyExampleGroup
+    context "on #{os}" do
       let :facts do
         facts
       end
@@ -12,7 +12,7 @@ describe 'php::fpm::pool' do
 
       case facts[:os]['name']
       when 'Debian'
-        context 'plain config' do # rubocop: disable RSpec/EmptyExampleGroup
+        context 'plain config' do
           let(:title) { 'unique-name' }
           let(:params) { {} }
 
@@ -26,7 +26,7 @@ describe 'php::fpm::pool' do
           end
         end
       when 'Ubuntu'
-        context 'plain config' do # rubocop: disable RSpec/EmptyExampleGroup
+        context 'plain config' do
           let(:title) { 'unique-name' }
           let(:params) { {} }
 


### PR DESCRIPTION
newer distributions, like Arch Linux, do not ship `service` anymore. If systemd is the used init system, we should also use the systemd cli to reload a service. This is required to fix Arch Linux acceptance tests (besides #663 )