### PR TITLE
Support other versions of remi repo on redhat

### DIFF
--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -7,12 +7,14 @@
 #
 
 class php::repo::redhat (
-  String[1] $yum_repo = 'remi_php56',
+  $version = '5.6',
 ) {
+
   $releasever = $facts['os']['name'] ? {
     /(?i:Amazon)/ => '6',
     default       => '$releasever',  # Yum var
   }
+  $no_dot_version = $version.delete('.')
 
   yumrepo { 'remi':
     descr      => 'Remi\'s RPM repository for Enterprise Linux $releasever - $basearch',
@@ -23,9 +25,9 @@ class php::repo::redhat (
     priority   => 1,
   }
 
-  yumrepo { 'remi-php56':
-    descr      => 'Remi\'s PHP 5.6 RPM repository for Enterprise Linux $releasever - $basearch',
-    mirrorlist => "https://rpms.remirepo.net/enterprise/${releasever}/php56/mirror",
+  yumrepo { "remi-php${no_dot_version}":
+    descr      => "Remi's PHP ${version} RPM repository for Enterprise Linux \$releasever - \$basearch",
+    mirrorlist => "https://rpms.remirepo.net/enterprise/${releasever}/php${no_dot_version}/mirror",
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => 'https://rpms.remirepo.net/RPM-GPG-KEY-remi',

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -7,9 +7,8 @@
 #
 
 class php::repo::redhat (
-  $version = '5.6',
+  String[1] $version = '5.6',
 ) {
-
   $releasever = $facts['os']['name'] ? {
     /(?i:Amazon)/ => '6',
     default       => '$releasever',  # Yum var

--- a/spec/acceptance/php_repo_redhat_spec.rb
+++ b/spec/acceptance/php_repo_redhat_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'spec_helper_acceptance'
+
+describe 'with RedHat', if: (fact('os.family') == 'RedHat') do
+  context 'default parameters' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+        include 'php::repo::redhat'
+        PUPPET
+      end
+    end
+    describe yumrepo('remi-php56') do
+      it { should exist }
+    end
+  end
+
+  context 'with version 7.2' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+        class { 'php::repo::redhat':
+          version => '7.2',
+        }
+        PUPPET
+      end
+    end
+    describe yumrepo('remi-php72') do
+      it { should exist }
+    end
+  end
+end

--- a/spec/classes/php_repo_redhat_spec.rb
+++ b/spec/classes/php_repo_redhat_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe 'php::repo::redhat', type: :class do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      case facts[:osfamily]
+      when 'RedHat'
+        describe 'when called with no parameters on RedHat' do
+          it { is_expected.to contain_yumrepo('remi-php56') }
+        end
+
+        describe 'when called with version 7.0 on RedHat' do
+          let(:params) do
+            {
+              version: '7.0'
+            }
+          end
+
+          it { is_expected.to contain_yumrepo('remi-php70') }
+        end
+
+        describe 'when call with version 7.1 on RedHat' do
+          let(:params) do
+            {
+              version: '7.1'
+            }
+          end
+
+          it { is_expected.to contain_yumrepo('remi-php71') }
+        end
+
+        describe 'when call with version 7.2 on RedHat' do
+          let(:params) do
+            {
+              version: '7.2'
+            }
+          end
+
+          it { is_expected.to contain_yumrepo('remi-php72') }
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently the class php::repo::redhat is hardcoded to create only the remi56 repo. This request removes that static value and creates based on $yum_repo. This allows for other versions such as remi_php72, etc..