### PR TITLE
Add ZendPHP support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,3 +9,4 @@ fixtures:
     yumrepo_core:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"
+    zend_common: "https://github.com/zendtech/puppet-zend-common.git"

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -15,13 +15,20 @@
 #   The mode specifies the specifics in paths for the various RedHat SCL environments so that the module is configured
 #   correctly on their pathnames.
 #
+# @param flavor
+#   Flavor of PHP, either 'community' or 'zend'.
+#
+# @param zend_creds
+#   Hash of ZendPHP repo credentials; {username => '<USERNAME>', password => '<PASSWORD>'}
+#
 
 class php::globals (
-
   Optional[Pattern[/^(rh-)?(php)?[578](\.)?[0-9]/]] $php_version = undef,
-  Optional[Stdlib::Absolutepath] $config_root   = undef,
-  Optional[Stdlib::Absolutepath] $fpm_pid_file  = undef,
-  Optional[Enum['rhscl', 'remi']] $rhscl_mode   = undef,
+  Optional[Stdlib::Absolutepath] $config_root                    = undef,
+  Optional[Stdlib::Absolutepath] $fpm_pid_file                   = undef,
+  Optional[Enum['rhscl', 'remi']] $rhscl_mode                    = undef,
+  Optional[Hash] $zend_creds                                     = undef,
+  Enum['community', 'zend'] $flavor                              = 'community',
 ) {
   if ($php_version == undef) {
     $globals_php_version = $facts['os']['name'] ? {
@@ -47,13 +54,22 @@ class php::globals (
       if $facts['os']['name'] == 'Ubuntu' {
         case $globals_php_version {
           /^[578].[0-9]/: {
-            $default_config_root = "/etc/php/${globals_php_version}"
+            case $flavor {
+              'zend': {
+                $default_config_root = "/etc/php/${globals_php_version}-zend"
+                $fpm_service_name = "php${globals_php_version}-zend-fpm"
+                $package_prefix = "php${globals_php_version}-zend-"
+              }
+              default: {
+                $default_config_root = "/etc/php/${globals_php_version}"
+                $fpm_service_name = "php${globals_php_version}-fpm"
+                $package_prefix = "php${globals_php_version}-"
+              }
+            }
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
             $fpm_error_log = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name = "php${globals_php_version}-fpm"
             $ext_tool_enable = "/usr/sbin/phpenmod -v ${globals_php_version}"
             $ext_tool_query = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix = "php${globals_php_version}-"
           }
           default: {
             # Default php installation from Ubuntu official repository use the following paths until 16.04
@@ -72,13 +88,22 @@ class php::globals (
           /^5\.6/,
           /^7\.[0-9]/,
           /^8\.[0-9]/: {
-            $default_config_root  = "/etc/php/${globals_php_version}"
+            case $flavor {
+              'zend': {
+                $default_config_root = "/etc/php/${globals_php_version}-zend"
+                $fpm_service_name = "php${globals_php_version}-zend-fpm"
+                $package_prefix = "php${globals_php_version}-zend-"
+              }
+              default: {
+                $default_config_root = "/etc/php/${globals_php_version}"
+                $fpm_service_name = "php${globals_php_version}-fpm"
+                $package_prefix = "php${globals_php_version}-"
+              }
+            }
             $default_fpm_pid_file = "/var/run/php/php${globals_php_version}-fpm.pid"
             $fpm_error_log        = "/var/log/php${globals_php_version}-fpm.log"
-            $fpm_service_name     = "php${globals_php_version}-fpm"
             $ext_tool_enable      = "/usr/sbin/phpenmod -v ${globals_php_version}"
             $ext_tool_query       = "/usr/sbin/phpquery -v ${globals_php_version}"
-            $package_prefix       = "php${globals_php_version}-"
           }
           default: {
             $default_config_root = '/etc/php5'
@@ -109,29 +134,41 @@ class php::globals (
       }
     }
     'RedHat': {
-      case $rhscl_mode {
-        'remi': {
-          $rhscl_root             = "/opt/remi/${php_version}/root"
-          $default_config_root    = "/etc/opt/remi/${php_version}"
+      case $flavor {
+        'zend': {
+          $php_version_sans_dot = $php_version.regsubst(/\./, '', 'G')
+          $default_config_root    = "/etc/opt/zend/php${php_version_sans_dot}zend"
           $default_fpm_pid_file   = '/var/run/php-fpm/php-fpm.pid'
-          $package_prefix         = "${php_version}-php-"
-          $fpm_service_name       = "${php_version}-php-fpm"
+          $fpm_service_name       = "php${php_version_sans_dot}zend-php-fpm"
+          $package_prefix         = "php${php_version_sans_dot}zend-php-"
         }
-        'rhscl': {
-          $rhscl_root             = "/opt/rh/${php_version}/root"
-          $default_config_root    = "/etc/opt/rh/${php_version}" # rhscl registers contents by copy in /etc/opt/rh
-          $default_fpm_pid_file   = "/var/opt/rh/${php_version}/run/php-fpm/php-fpm.pid"
-          $package_prefix         = "${php_version}-php-"
-          $fpm_service_name       = "${php_version}-php-fpm"
-        }
-        undef: {
-          $default_config_root    = '/etc/php.d'
-          $default_fpm_pid_file   = '/var/run/php-fpm/php-fpm.pid'
-          $fpm_service_name       = undef
-          $package_prefix         = undef
-        }
+
         default: {
-          fail("Unsupported rhscl_mode '${rhscl_mode}'")
+          case $rhscl_mode {
+            'remi': {
+              $rhscl_root             = "/opt/remi/${php_version}/root"
+              $default_config_root    = "/etc/opt/remi/${php_version}"
+              $default_fpm_pid_file   = '/var/run/php-fpm/php-fpm.pid'
+              $package_prefix         = "${php_version}-php-"
+              $fpm_service_name       = "${php_version}-php-fpm"
+            }
+            'rhscl': {
+              $rhscl_root             = "/opt/rh/${php_version}/root"
+              $default_config_root    = "/etc/opt/rh/${php_version}" # rhscl registers contents by copy in /etc/opt/rh
+              $default_fpm_pid_file   = "/var/opt/rh/${php_version}/run/php-fpm/php-fpm.pid"
+              $package_prefix         = "${php_version}-php-"
+              $fpm_service_name       = "${php_version}-php-fpm"
+            }
+            undef: {
+              $default_config_root    = '/etc/php.d'
+              $default_fpm_pid_file   = '/var/run/php-fpm/php-fpm.pid'
+              $fpm_service_name       = undef
+              $package_prefix         = undef
+            }
+            default: {
+              fail("Unsupported rhscl_mode '${rhscl_mode}'")
+            }
+          }
         }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,17 +58,25 @@ class php::params inherits php::globals {
       $ext_tool_enabled        = true
       $pear                    = true
 
-      case $facts['os']['name'] {
-        'Debian': {
-          $manage_repos = false
-        }
-
-        'Ubuntu': {
-          $manage_repos = false
+      case $php::globals::flavor {
+        'zend': {
+          $manage_repos = true
         }
 
         default: {
-          $manage_repos = false
+          case $facts['os']['name'] {
+            'Debian': {
+              $manage_repos = false
+            }
+
+            'Ubuntu': {
+              $manage_repos = false
+            }
+
+            default: {
+              $manage_repos = false
+            }
+          }
         }
       }
     }
@@ -121,36 +129,49 @@ class php::params inherits php::globals {
     'RedHat': {
       $config_root      = $php::globals::globals_config_root
 
-      case $php::globals::rhscl_mode {
-        'remi': {
+      case $php::globals::flavor {
+        'zend': {
           $config_root_ini         = "${config_root}/php.d"
           $config_root_inifile     = "${config_root}/php.ini"
           $cli_inifile             = $config_root_inifile
           $fpm_inifile             = $config_root_inifile
           $fpm_config_file         = "${config_root}/php-fpm.conf"
           $fpm_pool_dir            = "${config_root}/php-fpm.d"
-          $php_bin_dir             = "${php::globals::rhscl_root}/bin"
         }
-        'rhscl': {
-          $config_root_ini         = "${config_root}/php.d"
-          $config_root_inifile     = "${config_root}/php.ini"
-          $cli_inifile             = "${config_root}/php-cli.ini"
-          $fpm_inifile             = "${config_root}/php-fpm.ini"
-          $fpm_config_file         = "${config_root}/php-fpm.conf"
-          $fpm_pool_dir            = "${config_root}/php-fpm.d"
-          $php_bin_dir             = "${php::globals::rhscl_root}/bin"
-        }
-        undef: {
-          # no rhscl
-          $config_root_ini         = $config_root
-          $config_root_inifile     = '/etc/php.ini'
-          $cli_inifile             = '/etc/php-cli.ini'
-          $fpm_inifile             = '/etc/php-fpm.ini'
-          $fpm_config_file         = '/etc/php-fpm.conf'
-          $fpm_pool_dir            = '/etc/php-fpm.d'
-        }
+
         default: {
-          fail("Unsupported rhscl_mode '${php::globals::rhscl_mode}'")
+          case $php::globals::rhscl_mode {
+            'remi': {
+              $config_root_ini         = "${config_root}/php.d"
+              $config_root_inifile     = "${config_root}/php.ini"
+              $cli_inifile             = $config_root_inifile
+              $fpm_inifile             = $config_root_inifile
+              $fpm_config_file         = "${config_root}/php-fpm.conf"
+              $fpm_pool_dir            = "${config_root}/php-fpm.d"
+              $php_bin_dir             = "${php::globals::rhscl_root}/bin"
+            }
+            'rhscl': {
+              $config_root_ini         = "${config_root}/php.d"
+              $config_root_inifile     = "${config_root}/php.ini"
+              $cli_inifile             = "${config_root}/php-cli.ini"
+              $fpm_inifile             = "${config_root}/php-fpm.ini"
+              $fpm_config_file         = "${config_root}/php-fpm.conf"
+              $fpm_pool_dir            = "${config_root}/php-fpm.d"
+              $php_bin_dir             = "${php::globals::rhscl_root}/bin"
+            }
+            undef: {
+              # no rhscl
+              $config_root_ini         = $config_root
+              $config_root_inifile     = '/etc/php.ini'
+              $cli_inifile             = '/etc/php-cli.ini'
+              $fpm_inifile             = '/etc/php-fpm.ini'
+              $fpm_config_file         = '/etc/php-fpm.conf'
+              $fpm_pool_dir            = '/etc/php-fpm.d'
+            }
+            default: {
+              fail("Unsupported rhscl_mode '${php::globals::rhscl_mode}'")
+            }
+          }
         }
       }
 
@@ -168,7 +189,10 @@ class php::params inherits php::globals {
       $embedded_package_suffix = 'embedded'
       $package_prefix          = pick($php::globals::package_prefix, 'php-')
       $compiler_packages       = ['gcc', 'gcc-c++', 'make']
-      $manage_repos            = false
+      $manage_repos            = $php::globals::flavor ? {
+        'zend' => true,
+        default => false,
+      }
       $root_group              = 'root'
       $ext_tool_enable         = undef
       $ext_tool_query          = undef

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,30 +3,36 @@
 class php::repo {
   $msg_no_repo = "No repo available for ${facts['os']['family']}/${facts['os']['name']}"
 
-  case $facts['os']['family'] {
-    'Debian': {
-      # no contain here because apt does that already
-      case $facts['os']['name'] {
-        'Debian': {
-          include php::repo::debian
-        }
-        'Ubuntu': {
-          include php::repo::ubuntu
-        }
-        default: {
-          fail($msg_no_repo)
+  if $php::params::flavor == 'zend' {
+    class { 'zend_common::repo':
+      creds => $php::globals::zend_creds,
+    }
+  } else {
+    case $facts['os']['family'] {
+      'Debian': {
+        # no contain here because apt does that already
+        case $facts['os']['name'] {
+          'Debian': {
+            include php::repo::debian
+          }
+          'Ubuntu': {
+            include php::repo::ubuntu
+          }
+          default: {
+            fail($msg_no_repo)
+          }
         }
       }
-    }
-    'FreeBSD': {}
-    'Suse': {
-      contain php::repo::suse
-    }
-    'RedHat': {
-      contain 'php::repo::redhat'
-    }
-    default: {
-      fail($msg_no_repo)
+      'FreeBSD': {}
+      'Suse': {
+        contain php::repo::suse
+      }
+      'RedHat': {
+        contain 'php::repo::redhat'
+      }
+      default: {
+        fail($msg_no_repo)
+      }
     }
   }
 }

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -307,6 +307,34 @@ describe 'php', type: :class do
         it { is_expected.not_to contain_class('php::composer') }
       end
 
+      if facts[:osfamily] == 'RedHat' || facts[:osfamily] == 'CentOS' || facts[:osfamily] == 'Debian'
+        describe 'when called with flavor zend' do
+          zendphp_cli_package = case facts[:os]['name']
+                                when 'Debian', 'Ubuntu'
+                                  'php8.1-zend-cli'
+                                when 'RedHat', 'CentOS'
+                                  'php81zend-php-cli'
+                                end
+          zendphp_fpm_package = case facts[:os]['name']
+                                when 'Debian', 'Ubuntu'
+                                  'php8.1-zend-fpm'
+                                when 'RedHat', 'CentOS'
+                                  'php81zend-php-fpm'
+                                end
+
+          let(:pre_condition) do
+            "class {'php::globals':
+                      php_version => '8.1',
+                      flavor      => 'zend'
+            }"
+          end
+
+          it { is_expected.to contain_class('zend_common::repo') }
+          it { is_expected.to contain_package(zendphp_cli_package).with_ensure('present') }
+          it { is_expected.to contain_package(zendphp_fpm_package).with_ensure('present') }
+        end
+      end
+
       if facts[:osfamily] == 'RedHat' || facts[:osfamily] == 'CentOS'
         describe 'when called with valid settings parameter types' do
           let(:params) do


### PR DESCRIPTION
### Description

This PR adds support for ZendPHP on its [supported platforms](https://help.zend.com/zendphp/current/content/introduction/supported_platforms.htm).

This is accomplished by adding two parameters to `php::globals`:

- Optional[Enum['community', 'zend']] $flavor
- Optional[Hash] $zend_creds

### Usage examples

```puppet
class { '::php::globals':
  php_version => '8.1',
  flavor      => 'zend',
}->
class { '::php':
  fpm       => true,
  fpm_pools => {
    www => {
      listen => "127.0.0.1:9000",
    },
  }
}
```

```puppet
class { '::php::globals':
  php_version => '5.6',
  flavor      => 'zend',
  zend_creds  => {
    'username' => '<USERNAME>',
    'password' => '<PASSWORD>',
  },
}->
class { '::php':
  fpm       => true,
  fpm_pools => {
    www => {
      listen => "127.0.0.1:9000",
    },
  }
}
```


