### PR TITLE
fpm: fix FreeBSD support

### DIFF
--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -34,7 +34,7 @@ class php::fpm::service (
   if $reload_fpm_on_config_changes {
     $restart = $facts['service_provider'] ? {
       'systemd' => "systemctl reload ${service_name}",
-      undef     => "service ${service_name} reload"
+      default   => "service ${service_name} reload"
     }
   } else {
     $restart = undef


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
FreeBSD support for the FPM service broke in https://github.com/voxpupuli/puppet-php/commit/168d9b0e9a34cb58f7495b491a77b2b57d3e54ec, resulting in the following error message:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error:
No matching entry for selector parameter with value 'freebsd' (file: /etc/puppetlabs/code/environments/production/modules/php/manifests/fpm/service.pp, line: 35, column: 16) on node
```

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
