### PR TITLE
Add class parameter `fpm_log_dir_mode` to customize the file permission of log directory

### DIFF
--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -89,7 +89,7 @@ class php::fpm::config (
   Optional[Php::Duration] $systemd_interval                             = undef,
   String $log_owner                                                     = $php::params::fpm_user,
   String $log_group                                                     = $php::params::fpm_group,
-  Pattern[/^\d+$/] $log_dir_mode                                        = $php::params::fpm_log_dir_mode,
+  Stdlib::Filemode $log_dir_mode                                        = $php::params::fpm_log_dir_mode,
   String[1] $root_group                                                 = $php::params::root_group,
   String $syslog_facility                                               = 'daemon',
   String $syslog_ident                                                  = 'php-fpm',

--- a/manifests/fpm/config.pp
+++ b/manifests/fpm/config.pp
@@ -89,7 +89,7 @@ class php::fpm::config (
   Optional[Php::Duration] $systemd_interval                             = undef,
   String $log_owner                                                     = $php::params::fpm_user,
   String $log_group                                                     = $php::params::fpm_group,
-  Pattern[/^\d+$/] $log_dir_mode                                        = '0770',
+  Pattern[/^\d+$/] $log_dir_mode                                        = $php::params::fpm_log_dir_mode,
   String[1] $root_group                                                 = $php::params::root_group,
   String $syslog_facility                                               = 'daemon',
   String $syslog_ident                                                  = 'php-fpm',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,6 +147,7 @@ class php (
   Optional[String[1]] $fpm_package                = undef,
   String[1] $fpm_user                             = $php::params::fpm_user,
   String[1] $fpm_group                            = $php::params::fpm_group,
+  Pattern[/^\d+$/] $fpm_log_dir_mode              = $php::params::fpm_log_dir_mode,
   Boolean $embedded                               = false,
   Boolean $dev                                    = true,
   Boolean $composer                               = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,7 +147,7 @@ class php (
   Optional[String[1]] $fpm_package                = undef,
   String[1] $fpm_user                             = $php::params::fpm_user,
   String[1] $fpm_group                            = $php::params::fpm_group,
-  Pattern[/^\d+$/] $fpm_log_dir_mode              = $php::params::fpm_log_dir_mode,
+  Stdlib::Filemode $fpm_log_dir_mode              = $php::params::fpm_log_dir_mode,
   Boolean $embedded                               = false,
   Boolean $dev                                    = true,
   Boolean $composer                               = true,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class php::params inherits php::globals {
   $phpunit_path        = '/usr/local/bin/phpunit'
   $phpunit_max_age     = 30
   $pool_purge          = false
+  $fpm_log_dir_mode    = '0770'
 
   $fpm_pools = {
     'www' => {

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -256,7 +256,9 @@ describe 'php', type: :class do
       describe 'when called with fpm_log_dir_mode parameter' do
         let(:params) { { fpm_log_dir_mode: '0770' } }
 
-        it { is_expected.to contain_file('/var/log/php-fpm/').with_content(%r{mode = '0770'}) }
+        dstfile = '/var/log/php-fpm/'
+
+        it { is_expected.to contain_file(dstfile).with_mode('0770') }
       end
 
       describe 'when configured with a pool with apparmor_hat parameter' do

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -257,7 +257,6 @@ describe 'php', type: :class do
         let(:params) { { fpm_log_dir_mode: '0770' } }
 
         it { is_expected.to contain_file('/var/log/php-fpm/').with_content(%r{mode = '0770'}) }
-
       end
 
       describe 'when configured with a pool with apparmor_hat parameter' do

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -253,6 +253,13 @@ describe 'php', type: :class do
         it { is_expected.to contain_file(dstfile).with_content(%r{group = nginx}) }
       end
 
+      describe 'when called with fpm_log_dir_mode parameter' do
+        let(:params) { { fpm_log_dir_mode: '0770' } }
+
+        it { is_expected.to contain_file('/var/log/php-fpm/').with_content(%r{mode = '0770'}) }
+
+      end
+
       describe 'when configured with a pool with apparmor_hat parameter' do
         let(:params) { { fpm_pools: { 'www' => { 'apparmor_hat' => 'www' } } } }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

I created the PR to parametrize the file permission for the php-fpm log directory.


#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
