### PR TITLE
fpm: manage runtime- and log directory based on params

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1119,6 +1119,9 @@ Configure php-fpm service
 [*error_log*]
   Path to error log file. If it's set to "syslog", log is
   sent to syslogd instead of being written in a local file.
+  The base directory will be managed if it is a directory
+  dedicated to PHP (i.e. has "php" in its name and is not
+  a shared location like /var/log)
 
 [*log_level*]
   The php-fpm log level
@@ -1160,7 +1163,9 @@ Configure php-fpm service
   UNIX group of the root user
 
 [*pid_file*]
-  Path to fpm pid file
+  Path to fpm pid file. The base directory will be managed if it is
+  a directory dedicated to PHP (i.e. has "php" in its name and is not
+  a shared location like /var/run)
 
 [*manage_run_dir*]
   Manage the run directory

--- a/spec/classes/php_fpm_config_spec.rb
+++ b/spec/classes/php_fpm_config_spec.rb
@@ -44,6 +44,70 @@ describe 'php::fpm::config' do
           )
         end
       end
+
+      describe 'manages a log directory' do
+        context 'with dedicated path' do
+          let(:params) do
+            {
+              error_log: '/var/log/php/fpm.log',
+            }
+          end
+
+          it do
+            is_expected.to contain_file('/var/log/php')
+          end
+        end
+
+        context 'without dedicated path' do
+          let(:params) do
+            {
+              error_log: '/var/log/php-fpm.log',
+            }
+          end
+
+          it do
+            is_expected.not_to contain_file('/var/log')
+          end
+        end
+
+        context 'without syslog logging' do
+          let(:params) do
+            {
+              error_log: 'syslog',
+            }
+          end
+
+          it do
+            is_expected.not_to contain_file('syslog')
+          end
+        end
+      end
+
+      describe 'manages a runtime directory' do
+        context 'with dedicated path' do
+          let(:params) do
+            {
+              pid_file: '/var/run/php/fpm.pid',
+            }
+          end
+
+          it do
+            is_expected.to contain_file('/var/run/php')
+          end
+        end
+
+        context 'without dedicated path' do
+          let(:params) do
+            {
+              pid_file: '/var/run/fpm.pid',
+            }
+          end
+
+          it do
+            is_expected.not_to contain_file('/var/run')
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
instead of hardcoding the paths for the log- and runtime directory, calculate them based on the error_log and pid_file params respectively. the directories will not be managed if they are shared system locations like `/var/log` or `/run` (this is checked by ensuring the directories have *php* in their name, signalling that those are paths dedicated to PHP)

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
