### PR TITLE
Release 10.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v10.1.0](https://github.com/voxpupuli/puppet-php/tree/v10.1.0) (2023-11-22)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-php/compare/v10.0.0...v10.1.0)
+
+**Implemented enhancements:**
+
+- metadata.json: allow puppet/zypprepo 5.x [\#702](https://github.com/voxpupuli/puppet-php/pull/702) ([kenyon](https://github.com/kenyon))
+
+**Closed issues:**
+
+- Dependency conflict between puppet-php and puppet-zypprepo [\#701](https://github.com/voxpupuli/puppet-php/issues/701)
+
 ## [v10.0.0](https://github.com/voxpupuli/puppet-php/tree/v10.0.0) (2023-09-22)
 
 [Full Changelog](https://github.com/voxpupuli/puppet-php/compare/v9.0.0...v10.0.0)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-php",
-  "version": "10.0.1-rc0",
+  "version": "10.1.0",
   "author": "Vox Pupuli",
   "summary": "Generic PHP module that supports many platforms",
   "license": "MIT",


### PR DESCRIPTION
#### Pull Request (PR) description

This PR prepares the release of `puppet-php` 10.1.0 which fixes a dependency issue. It is the successor of PR #703.

#### This Pull Request (PR) fixes the following issues

Fixes: #701