### PR TITLE
Fix behavior of php::packages::names_to_prefix

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -15,12 +15,13 @@
 class php::packages (
   String $ensure         = $php::ensure,
   Boolean $manage_repos  = $php::manage_repos,
-  Array $names_to_prefix = prefix($php::params::common_package_suffixes, $php::package_prefix),
+  Array $names_to_prefix = $php::params::common_package_suffixes,
   Array $names           = $php::params::common_package_names,
 ) inherits php::params {
   assert_private()
 
-  $real_names = union($names, $names_to_prefix)
+  $names_with_prefix = prefix($names_to_prefix, $php::package_prefix)
+  $real_names = union($names, $names_with_prefix)
   if $facts['os']['family'] == 'Debian' {
     if $manage_repos {
       include apt


### PR DESCRIPTION
#### Pull Request (PR) description
The documentation for `php::packages::names_to_prefix` suggests that the module will add `php::package_prefix` to the beginning of the listed package names.  However, since the `prefix()` function is in the parameter default, the prefix is only applied to the default value (`php::params::common_package_suffixes`) rather than to user-defined `php::packages::names_to_prefix`.  This commit fixes that behavior, so that either the default or user-defined `php::packages::names_to_prefix` will have prefixes added by the module.

#### This Pull Request (PR) fixes the following issues
n/a