### PR TITLE
add some fact checks to not add php5.6 repo to new alma/redhat system…

### DIFF
--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -14,21 +14,27 @@ class php::repo::redhat (
     default       => '$releasever',  # Yum var
   }
 
+  $basearch = $facts['architecture'] ? {
+    default     => '$basearch',  # Yum var
+  }
+
   yumrepo { 'remi':
     descr      => 'Remi\'s RPM repository for Enterprise Linux $releasever - $basearch',
-    mirrorlist => "https://rpms.remirepo.net/enterprise/${releasever}/remi/mirror",
+    mirrorlist => "https://rpms.remirepo.net/enterprise/${releasever}/remi/${basearch}/mirror",
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => 'https://rpms.remirepo.net/RPM-GPG-KEY-remi',
     priority   => 1,
   }
 
+if (! ($facts['os']['name'] in ['AlmaLinux','Redhat'])) and ($facts['distro']['major'] in ['8','9'])  {
   yumrepo { 'remi-php56':
     descr      => 'Remi\'s PHP 5.6 RPM repository for Enterprise Linux $releasever - $basearch',
-    mirrorlist => "https://rpms.remirepo.net/enterprise/${releasever}/php56/mirror",
+    mirrorlist => "https://rpms.remirepo.net/enterprise/${releasever}/php56/${basearch}/mirror",
     enabled    => 1,
     gpgcheck   => 1,
     gpgkey     => 'https://rpms.remirepo.net/RPM-GPG-KEY-remi2023',
     priority   => 1,
   }
+}
 }


### PR DESCRIPTION
#### Pull Request (PR) description
current redhat.pp will add wrong .repo files to new redhat and almalinux (8 and 9) systems. You run into a 404 by default with this redhat.pp

#### This Pull Request (PR) fixes the following issues
Now we check the releaseversion, and if you run a AlmaLinux or Redhat System in version 8 or 9, you will not receive the remi-php56.repo file, because there is no existing repo url.

Cheers
Christian