### PR TITLE
adopt new service name on FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -217,7 +217,7 @@ class php::params inherits php::globals {
       $fpm_inifile             = "${config_root}/php-fpm.ini"
       $fpm_package_suffix      = undef
       $fpm_pool_dir            = "${config_root}/php-fpm.d"
-      $fpm_service_name        = 'php-fpm'
+      $fpm_service_name        = 'php_fpm'
       $fpm_user                = 'www'
       $fpm_group               = 'www'
       $embedded_package_suffix = 'embed'

--- a/spec/classes/php_fpm_service_spec.rb
+++ b/spec/classes/php_fpm_service_spec.rb
@@ -39,7 +39,9 @@ describe 'php::fpm::service', type: :class do
           when '20.04', '11'
             it { is_expected.to contain_service('php7.4-fpm').with_ensure('running') }
           end
-        when 'Suse', 'FreeBSD'
+        when 'FreeBSD'
+          it { is_expected.to contain_service('php_fpm').with_ensure('running') }
+        when 'Suse'
           it { is_expected.to contain_service('php-fpm').with_ensure('running') }
         end
       end

--- a/spec/classes/php_fpm_spec.rb
+++ b/spec/classes/php_fpm_spec.rb
@@ -39,7 +39,7 @@ describe 'php::fpm', type: :class do
           it { is_expected.not_to contain_package('php56-') }
           it { is_expected.not_to contain_package('php5-fpm') }
           it { is_expected.not_to contain_package('php-fpm') }
-          it { is_expected.to contain_service('php-fpm').with_ensure('running') }
+          it { is_expected.to contain_service('php_fpm').with_ensure('running') }
         else
           it { is_expected.to contain_package('php-fpm').with_ensure('present') }
           it { is_expected.to contain_service('php-fpm').with_ensure('running') }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The service name on FreeBSD has been renamed from `php-fpm` to `php_fpm`.

Related upstream commit:
https://github.com/FreeBSD/freebsd-ports/commit/55272c38747e54876219ffcb73050514bfd21d0d

#### This Pull Request (PR) fixes the following issues
none