### PR TITLE
add: support for apache-specific extension config on Debian

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,9 @@
 ---
 fixtures:
   repositories:
-    apt: https://github.com/puppetlabs/puppetlabs-apt.git
+    apt:
+      repo: https://github.com/puppetlabs/puppetlabs-apt.git
+      tag: v10.0.1
     archive: https://github.com/voxpupuli/puppet-archive.git
     inifile: https://github.com/puppetlabs/puppetlabs-inifile.git
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,7 @@
 ---
 fixtures:
   repositories:
-    apt:
-      repo: https://github.com/puppetlabs/puppetlabs-apt.git
-      tag: v10.0.1
+    apt: https://github.com/puppetlabs/puppetlabs-apt.git
     archive: https://github.com/voxpupuli/puppet-archive.git
     inifile: https://github.com/puppetlabs/puppetlabs-inifile.git
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -147,7 +147,8 @@ enabled components.
 [*apache_ini*]
   This is the path to the config .ini files of the extensions specific to Apache.
   This should only be applicable on Debian/Ubuntu systems, and defaults to
-  "${config_root_ini}/apache2/conf.d".
+  "${config_root_ini}/apache2/conf.d". On other operating systems, this
+  defaults to the same value as $config_root_ini.
 
 [*ext_tool_enable*]
   Absolute path to php tool for enabling extensions in debian/ubuntu systems.
@@ -472,7 +473,7 @@ Default value: `$php::params::config_root_inifile`
 
 ##### <a name="-php--apache_ini"></a>`apache_ini`
 
-Data type: `Stdlib::Absolutepath`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -144,6 +144,11 @@ enabled components.
   The path to the global php.ini file. This defaults to a sensible default
   depending on your operating system.
 
+[*apache_ini*]
+  This is the path to the config .ini files of the extensions specific to Apache.
+  This should only be applicable on Debian/Ubuntu systems, and defaults to
+  "${config_root_ini}/apache2/conf.d".
+
 [*ext_tool_enable*]
   Absolute path to php tool for enabling extensions in debian/ubuntu systems.
   This defaults to '/usr/sbin/php5enmod'.
@@ -224,6 +229,7 @@ The following parameters are available in the `php` class:
 * [`package_prefix`](#-php--package_prefix)
 * [`config_root_ini`](#-php--config_root_ini)
 * [`config_root_inifile`](#-php--config_root_inifile)
+* [`apache_ini`](#-php--apache_ini)
 * [`ext_tool_enable`](#-php--ext_tool_enable)
 * [`ext_tool_query`](#-php--ext_tool_query)
 * [`ext_tool_enabled`](#-php--ext_tool_enabled)
@@ -463,6 +469,14 @@ Data type: `Stdlib::Absolutepath`
 
 
 Default value: `$php::params::config_root_inifile`
+
+##### <a name="-php--apache_ini"></a>`apache_ini`
+
+Data type: `Stdlib::Absolutepath`
+
+
+
+Default value: `$php::params::apache_ini`
 
 ##### <a name="-php--ext_tool_enable"></a>`ext_tool_enable`
 

--- a/manifests/extension/config.pp
+++ b/manifests/extension/config.pp
@@ -99,6 +99,13 @@ define php::extension::config (
       file   => "${config_root_ini}/${ini_prefix}${ini_name}.ini",
       config => $final_settings,
     }
+    $_apache_ini = pick_default($php::apache_ini, $php::params::apache_ini)
+    if $php::apache_config and $facts['os']['family'] == 'Debian' {
+      php::config { "${title}_apache":
+        file   => "${_apache_ini}/${ini_prefix}${ini_name}.ini",
+        config => $final_settings,
+      }
+    }
 
     # Ubuntu/Debian systems use the mods-available folder. We need to enable
     # settings files ourselves with php5enmod command.

--- a/manifests/extension/config.pp
+++ b/manifests/extension/config.pp
@@ -94,15 +94,16 @@ define php::extension::config (
   }
 
   $config_root_ini = pick_default($php::config_root_ini, $php::params::config_root_ini)
+  $apache_ini     = pick_default($php::apache_ini, $php::params::apache_ini)
   if $real_ensure != 'absent' {
     php::config { $title:
       file   => "${config_root_ini}/${ini_prefix}${ini_name}.ini",
       config => $final_settings,
     }
-    $_apache_ini = pick_default($php::apache_ini, $php::params::apache_ini)
-    if $php::apache_config and $facts['os']['family'] == 'Debian' {
+
+    if $php::apache_config and ($apache_ini != $config_root_ini) {
       php::config { "${title}_apache":
-        file   => "${_apache_ini}/${ini_prefix}${ini_name}.ini",
+        file   => "${apache_ini}/${ini_prefix}${ini_name}.ini",
         config => $final_settings,
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,6 +86,11 @@
 #   The path to the global php.ini file. This defaults to a sensible default
 #   depending on your operating system.
 #
+# [*apache_ini*]
+#   This is the path to the config .ini files of the extensions specific to Apache.
+#   This should only be applicable on Debian/Ubuntu systems, and defaults to
+#   "${config_root_ini}/apache2/conf.d".
+#
 # [*ext_tool_enable*]
 #   Absolute path to php tool for enabling extensions in debian/ubuntu systems.
 #   This defaults to '/usr/sbin/php5enmod'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,6 +163,7 @@ class php (
   Optional[String[1]] $package_prefix             = $php::params::package_prefix,
   Stdlib::Absolutepath $config_root_ini           = $php::params::config_root_ini,
   Stdlib::Absolutepath $config_root_inifile       = $php::params::config_root_inifile,
+  Stdlib::Absolutepath $apache_ini                = $php::params::apache_ini,
   Optional[Stdlib::Absolutepath] $ext_tool_enable = $php::params::ext_tool_enable,
   Optional[Stdlib::Absolutepath] $ext_tool_query  = $php::params::ext_tool_query,
   Boolean $ext_tool_enabled                       = $php::params::ext_tool_enabled,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,8 @@
 # [*apache_ini*]
 #   This is the path to the config .ini files of the extensions specific to Apache.
 #   This should only be applicable on Debian/Ubuntu systems, and defaults to
-#   "${config_root_ini}/apache2/conf.d".
+#   "${config_root_ini}/apache2/conf.d". On other operating systems, this
+#   defaults to the same value as $config_root_ini.
 #
 # [*ext_tool_enable*]
 #   Absolute path to php tool for enabling extensions in debian/ubuntu systems.
@@ -168,7 +169,7 @@ class php (
   Optional[String[1]] $package_prefix             = $php::params::package_prefix,
   Stdlib::Absolutepath $config_root_ini           = $php::params::config_root_ini,
   Stdlib::Absolutepath $config_root_inifile       = $php::params::config_root_inifile,
-  Stdlib::Absolutepath $apache_ini                = $php::params::apache_ini,
+  Optional[Stdlib::Absolutepath] $apache_ini      = $php::params::apache_ini,
   Optional[Stdlib::Absolutepath] $ext_tool_enable = $php::params::ext_tool_enable,
   Optional[Stdlib::Absolutepath] $ext_tool_query  = $php::params::ext_tool_query,
   Boolean $ext_tool_enabled                       = $php::params::ext_tool_enabled,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -106,6 +106,7 @@ class php::params inherits php::globals {
       $fpm_service_name        = 'php-fpm'
       $fpm_user                = 'wwwrun'
       $fpm_group               = 'www'
+      $apache_ini              = undef
       $embedded_package_suffix = 'embed'
       $embedded_inifile        = "${config_root}/embed/php.ini"
       $package_prefix          = $php::globals::package_prefix
@@ -177,6 +178,7 @@ class php::params inherits php::globals {
         }
       }
 
+      $apache_ini              = $config_root_ini
       $apache_inifile          = $config_root_inifile
       $embedded_inifile        = $config_root_inifile
       $common_package_names    = []
@@ -221,6 +223,7 @@ class php::params inherits php::globals {
       $fpm_service_name        = 'php_fpm'
       $fpm_user                = 'www'
       $fpm_group               = 'www'
+      $apache_ini              = undef
       $embedded_package_suffix = 'embed'
       $embedded_inifile        = "${config_root}/php-embed.ini"
       $package_prefix          = $php::globals::package_prefix
@@ -248,6 +251,7 @@ class php::params inherits php::globals {
       $fpm_service_name        = 'php-fpm'
       $fpm_user                = 'http'
       $fpm_group               = 'http'
+      $apache_ini              = $config_root_ini
       $apache_inifile          = '/etc/php/php.ini'
       $embedded_package_suffix = 'embedded'
       $embedded_inifile        = '/etc/php/php.ini'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,6 +48,7 @@ class php::params inherits php::globals {
       $fpm_service_name        = $php::globals::fpm_service_name
       $fpm_user                = 'www-data'
       $fpm_group               = 'www-data'
+      $apache_ini              = "${config_root}/apache2/conf.d"
       $apache_inifile          = "${config_root}/apache2/php.ini"
       $embedded_package_suffix = 'embed'
       $embedded_inifile        = "${config_root}/embed/php.ini"

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -17,26 +17,26 @@ describe 'php::extension' do
                               when '13'
                                 ['/etc/php/8.4/mods-available', '/etc/php/8.4/apache2']
                               when '12'
-                                ['/etc/php/8.2/mods-available', '/etc/php/8.2/apache2']
+                                ['/etc/php/8.2/mods-available', '/etc/php/8.2/apache2/conf.d']
                               when '11'
-                                ['/etc/php/7.4/mods-available', '/etc/php/7.4/apache2']
+                                ['/etc/php/7.4/mods-available', '/etc/php/7.4/apache2/conf.d']
                               when '10'
-                                ['/etc/php/7.3/mods-available', '/etc/php/7.3/apache2']
+                                ['/etc/php/7.3/mods-available', '/etc/php/7.3/apache2/conf.d']
                               else
-                                ['/etc/php5/mods-available', '/etc/php5/apache2']
+                                ['/etc/php5/mods-available', '/etc/php5/apache2/conf.d']
                               end
                             when 'Ubuntu'
                               case facts[:os]['release']['major']
                               when '24.04'
-                                ['/etc/php/8.3/mods-available', '/etc/php/8.3/apache2']
+                                ['/etc/php/8.3/mods-available', '/etc/php/8.3/apache2/conf.d']
                               when '22.04'
-                                ['/etc/php/8.1/mods-available', '/etc/php/8.1/apache2']
+                                ['/etc/php/8.1/mods-available', '/etc/php/8.1/apache2/conf.d']
                               when '20.04'
-                                ['/etc/php/7.4/mods-available', '/etc/php/7.4/apache2']
+                                ['/etc/php/7.4/mods-available', '/etc/php/7.4/apache2/conf.d']
                               when '18.04'
-                                ['/etc/php/7.2/mods-available', '/etc/php/7.2/apache2']
+                                ['/etc/php/7.2/mods-available', '/etc/php/7.2/apache2/conf.d']
                               else
-                                ['/etc/php5/mods-available', '/etc/php5/apache2']
+                                ['/etc/php5/mods-available', '/etc/php5/apache2/conf.d']
                               end
                             when 'Archlinux'
                               ['/etc/php/conf.d', '/etc/php/conf.d']

--- a/spec/defines/extension_spec.rb
+++ b/spec/defines/extension_spec.rb
@@ -11,38 +11,38 @@ describe 'php::extension' do
       let(:pre_condition) { 'include php' }
 
       unless facts[:os]['family'] == 'Suse' || facts[:os]['family'] == 'FreeBSD' # FIXME: something is wrong on these
-        etcdir =  case facts[:os]['name']
-                  when 'Debian'
-                    case facts[:os]['release']['major']
-                    when '13'
-                      '/etc/php/8.4/mods-available'
-                    when '12'
-                      '/etc/php/8.2/mods-available'
-                    when '11'
-                      '/etc/php/7.4/mods-available'
-                    when '10'
-                      '/etc/php/7.3/mods-available'
-                    else
-                      '/etc/php5/mods-available'
-                    end
-                  when 'Ubuntu'
-                    case facts[:os]['release']['major']
-                    when '24.04'
-                      '/etc/php/8.3/mods-available'
-                    when '22.04'
-                      '/etc/php/8.1/mods-available'
-                    when '20.04'
-                      '/etc/php/7.4/mods-available'
-                    when '18.04'
-                      '/etc/php/7.2/mods-available'
-                    else
-                      '/etc/php5/mods-available'
-                    end
-                  when 'Archlinux'
-                    '/etc/php/conf.d'
-                  else
-                    '/etc/php.d'
-                  end
+        etcdir, apachedir = case facts[:os]['name']
+                            when 'Debian'
+                              case facts[:os]['release']['major']
+                              when '13'
+                                ['/etc/php/8.4/mods-available', '/etc/php/8.4/apache2']
+                              when '12'
+                                ['/etc/php/8.2/mods-available', '/etc/php/8.2/apache2']
+                              when '11'
+                                ['/etc/php/7.4/mods-available', '/etc/php/7.4/apache2']
+                              when '10'
+                                ['/etc/php/7.3/mods-available', '/etc/php/7.3/apache2']
+                              else
+                                ['/etc/php5/mods-available', '/etc/php5/apache2']
+                              end
+                            when 'Ubuntu'
+                              case facts[:os]['release']['major']
+                              when '24.04'
+                                ['/etc/php/8.3/mods-available', '/etc/php/8.3/apache2']
+                              when '22.04'
+                                ['/etc/php/8.1/mods-available', '/etc/php/8.1/apache2']
+                              when '20.04'
+                                ['/etc/php/7.4/mods-available', '/etc/php/7.4/apache2']
+                              when '18.04'
+                                ['/etc/php/7.2/mods-available', '/etc/php/7.2/apache2']
+                              else
+                                ['/etc/php5/mods-available', '/etc/php5/apache2']
+                              end
+                            when 'Archlinux'
+                              ['/etc/php/conf.d', '/etc/php/conf.d']
+                            else
+                              ['/etc/php.d', '/etc/php.d']
+                            end
 
         context 'installation from repository' do
           let(:title) { 'json' }
@@ -217,6 +217,119 @@ describe 'php::extension' do
               end
 
               it { is_expected.to contain_exec('ext_tool_enable_xdebug') }
+            end
+
+            context 'when php::apache_config is true' do
+              let(:pre_condition) do
+                <<-PUPPET
+                  class { 'php':
+                    apache_config => true,
+                    config_root_ini => '#{etcdir}',
+                    apache_ini => '#{apachedir}',
+                  }
+                PUPPET
+              end
+
+              context 'creates apache config file when apache_ini differs from config_root_ini' do
+                let(:title) { 'json' }
+                let(:params) do
+                  {
+                    settings: {
+                      'test' => 'foo'
+                    }
+                  }
+                end
+
+                it 'creates main config file' do
+                  is_expected.to contain_php__config('json').with(
+                    file: "#{etcdir}/json.ini",
+                    config: {
+                      'extension' => 'json.so',
+                      'test' => 'foo'
+                    }
+                  )
+                end
+
+                it 'creates apache config file' do
+                  is_expected.to contain_php__config('json_apache').with(
+                    file: "#{apachedir}/json.ini",
+                    config: {
+                      'extension' => 'json.so',
+                      'test' => 'foo'
+                    }
+                  )
+                end
+              end
+
+              context 'with zend extension and custom settings' do
+                let(:title) { 'xdebug' }
+                let(:params) do
+                  {
+                    zend: true,
+                    settings: {
+                      'remote_enable' => 'on',
+                      'remote_host' => 'localhost'
+                    }
+                  }
+                end
+
+                it 'creates main zend config file' do
+                  is_expected.to contain_php__config('xdebug').with(
+                    file: "#{etcdir}/xdebug.ini",
+                    config: {
+                      'zend_extension' => 'xdebug.so',
+                      'remote_enable' => 'on',
+                      'remote_host' => 'localhost'
+                    }
+                  )
+                end
+
+                it 'creates apache zend config file' do
+                  is_expected.to contain_php__config('xdebug_apache').with(
+                    file: "#{apachedir}/xdebug.ini",
+                    config: {
+                      'zend_extension' => 'xdebug.so',
+                      'remote_enable' => 'on',
+                      'remote_host' => 'localhost'
+                    }
+                  )
+                end
+              end
+
+              context 'when apache_ini is same as config_root_ini' do
+                let(:pre_condition) do
+                  <<-PUPPET
+                    class { 'php':
+                      apache_config => true,
+                      config_root_ini => '#{etcdir}',
+                      apache_ini => '#{etcdir}',
+                    }
+                  PUPPET
+                end
+
+                let(:title) { 'json' }
+                let(:params) do
+                  {
+                    settings: {
+                      'test' => 'foo'
+                    }
+                  }
+                end
+
+                it 'creates only main config file' do
+                  is_expected.to contain_php__config('json').with(
+                    file: "#{etcdir}/json.ini",
+                    config: {
+                      'extension' => 'json.so',
+                      'test' => 'foo'
+                    }
+                  )
+                end
+
+                it 'does not create apache config file' do
+                  is_expected.not_to contain_php__config('json_apache')
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This ensures extension settings are configured in their respective Apache config files as well as the default cli config.

Current behavior:
Extension config file is created in the `apache2` subdirectory by `phpenmod`, but the settings defined in Puppet are not populated.

Tested on Ubuntu 20.04 + ondrej PHP 5.6 (environment that needed fixing), but should function on Debian + other versions, and the paths can be easily overridden.