### PR TITLE
Use packages.sury.org as the new APT source

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -27,7 +27,7 @@
 * [`php::repo::debian`](#php--repo--debian): Configure debian apt repo  === Parameters  [*location*]   Location of the apt repository  [*repos*]   Apt repository names  [*include_src*]  
 * [`php::repo::redhat`](#php--repo--redhat)
 * [`php::repo::suse`](#php--repo--suse): Configure suse repo  === Parameters  [*reponame*]   Name of the Zypper repository  [*baseurl*]   Base URL of the Zypper repository
-* [`php::repo::ubuntu`](#php--repo--ubuntu): Configure ubuntu ppa  === Parameters  [*version*]   PHP version to manage (e.g. 5.6)
+* [`php::repo::ubuntu`](#php--repo--ubuntu): Configure ubuntu apt repo (packages.sury.org)  === Parameters  [*location*]   Location of the apt repository  [*repos*]   Apt repository name
 
 ### Defined types
 
@@ -1834,6 +1834,7 @@ The following parameters are available in the `php::repo::debian` class:
 * [`key`](#-php--repo--debian--key)
 * [`dotdeb`](#-php--repo--debian--dotdeb)
 * [`sury`](#-php--repo--debian--sury)
+* [`key_source`](#-php--repo--debian--key_source)
 
 ##### <a name="-php--repo--debian--location"></a>`location`
 
@@ -1890,6 +1891,14 @@ Data type: `Boolean`
 
 Default value: `true`
 
+##### <a name="-php--repo--debian--key_source"></a>`key_source`
+
+Data type: `String[1]`
+
+
+
+Default value: `'https://packages.sury.org/php/apt.gpg'`
+
 ### <a name="php--repo--redhat"></a>`php::repo::redhat`
 
 The php::repo::redhat class.
@@ -1945,26 +1954,75 @@ Default value: `'http://download.opensuse.org/repositories/home:/mayflower:/php5
 
 ### <a name="php--repo--ubuntu"></a>`php::repo::ubuntu`
 
-Configure ubuntu ppa
+Configure ubuntu apt repo (packages.sury.org)
 
 === Parameters
 
+[*location*]
+  Location of the apt repository
+
+[*repos*]
+  Apt repository names
+
+[*include_src*]
+  Add source repository
+
+[*key_source*]
+  URL of the GPG key file
+
 [*version*]
-  PHP version to manage (e.g. 5.6)
+  Removed. PHP version selection via PPA is no longer supported.
+  All PHP versions are available from a single repository.
 
 #### Parameters
 
 The following parameters are available in the `php::repo::ubuntu` class:
 
+* [`location`](#-php--repo--ubuntu--location)
+* [`repos`](#-php--repo--ubuntu--repos)
+* [`include_src`](#-php--repo--ubuntu--include_src)
+* [`key_source`](#-php--repo--ubuntu--key_source)
 * [`version`](#-php--repo--ubuntu--version)
+
+##### <a name="-php--repo--ubuntu--location"></a>`location`
+
+Data type: `String[1]`
+
+
+
+Default value: `'https://packages.sury.org/php/'`
+
+##### <a name="-php--repo--ubuntu--repos"></a>`repos`
+
+Data type: `String[1]`
+
+
+
+Default value: `'main'`
+
+##### <a name="-php--repo--ubuntu--include_src"></a>`include_src`
+
+Data type: `Boolean`
+
+
+
+Default value: `false`
+
+##### <a name="-php--repo--ubuntu--key_source"></a>`key_source`
+
+Data type: `String[1]`
+
+
+
+Default value: `'https://packages.sury.org/php/apt.gpg'`
 
 ##### <a name="-php--repo--ubuntu--version"></a>`version`
 
-Data type: `Pattern[/^\d\.\d/]`
+Data type: `Optional[String]`
 
 
 
-Default value: `'5.6'`
+Default value: `undef`
 
 ## Defined types
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -203,6 +203,11 @@ class php (
 
   if $manage_repos {
     contain php::repo
+    if $facts['os']['family'] == 'Debian' {
+      Class['php::repo'] -> Class['apt::update'] -> Class['php::packages']
+    } else {
+      Class['php::repo'] -> Class['php::packages']
+    }
   }
 
   class { 'php::packages': }

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -30,6 +30,7 @@ class php::repo::debian (
   },
   Boolean $dotdeb         = true,
   Boolean $sury           = true,
+  String[1] $key_source   = 'https://packages.sury.org/php/apt.gpg',
 ) {
   assert_private()
 
@@ -51,6 +52,10 @@ class php::repo::debian (
   }
 
   if ($sury and versioncmp($facts['os']['release']['major'], '9') >= 0) {
+    apt::keyring { 'packages-sury-org.gpg':
+      source => $key_source,
+    }
+
     apt::source { 'source_php_sury':
       location => 'https://packages.sury.org/php/',
       repos    => 'main',
@@ -58,10 +63,8 @@ class php::repo::debian (
         'src' => $include_src,
         'deb' => true,
       },
-      key      => {
-        name   => 'php-sury.gpg',
-        source => 'https://packages.sury.org/php/apt.gpg',
-      },
+      keyring  => '/etc/apt/keyrings/packages-sury-org.gpg',
+      require  => Apt::Keyring['packages-sury-org.gpg'],
     }
   }
 }

--- a/manifests/repo/ubuntu.pp
+++ b/manifests/repo/ubuntu.pp
@@ -1,28 +1,52 @@
-# Configure ubuntu ppa
+# Configure ubuntu apt repo (packages.sury.org)
 #
 # === Parameters
 #
+# [*location*]
+#   Location of the apt repository
+#
+# [*repos*]
+#   Apt repository names
+#
+# [*include_src*]
+#   Add source repository
+#
+# [*key_source*]
+#   URL of the GPG key file
+#
 # [*version*]
-#   PHP version to manage (e.g. 5.6)
+#   Removed. PHP version selection via PPA is no longer supported.
+#   All PHP versions are available from a single repository.
 #
 class php::repo::ubuntu (
-  Pattern[/^\d\.\d/] $version = '5.6',
+  String[1] $location       = 'https://packages.sury.org/php/',
+  String[1] $repos          = 'main',
+  Boolean $include_src      = false,
+  String[1] $key_source     = 'https://packages.sury.org/php/apt.gpg',
+  Optional[String] $version = undef,
 ) {
   if $facts['os']['name'] != 'Ubuntu' {
     fail("class php::repo::ubuntu does not work on OS ${facts['os']['name']}")
   }
+
+  if $version != undef {
+    fail('php::repo::ubuntu: the $version parameter has been removed. packages.sury.org provides all PHP versions in a single repository.')
+  }
+
   include 'apt'
 
-  if ($version == '5.5') {
-    fail('PHP 5.5 is no longer available for download')
+  apt::keyring { 'packages-sury-org.gpg':
+    source => $key_source,
   }
 
-  $version_repo = $version ? {
-    '5.4'   => 'ondrej/php5-oldstable',
-    default => 'ondrej/php'
-  }
-
-  ::apt::ppa { "ppa:${version_repo}":
-    package_manage => true,
+  apt::source { 'source_php_sury':
+    location => $location,
+    repos    => $repos,
+    include  => {
+      'src' => $include_src,
+      'deb' => true,
+    },
+    keyring  => '/etc/apt/keyrings/packages-sury-org.gpg',
+    require  => Apt::Keyring['packages-sury-org.gpg'],
   }
 }

--- a/spec/classes/php_repo_debian_spec.rb
+++ b/spec/classes/php_repo_debian_spec.rb
@@ -26,9 +26,11 @@ describe 'php::repo::debian', type: :class do
           if facts[:os]['release']['major'].to_i < 9
             it { is_expected.to contain_apt__source('source_php_dotdeb') }
             it { is_expected.not_to contain_apt__source('source_php_sury') }
+            it { is_expected.not_to contain_apt__keyring('packages-sury-org.gpg') }
           elsif facts[:os]['release']['major'].to_i >= 9
             it { is_expected.not_to contain_apt__source('source_php_dotdeb') }
             it { is_expected.to contain_apt__source('source_php_sury') }
+            it { is_expected.to contain_apt__keyring('packages-sury-org.gpg') }
           end
         else
           it { is_expected.to compile.and_raise_error(%r{class php::repo::debian does not work on OS}) }

--- a/spec/classes/php_repo_ubuntu_spec.rb
+++ b/spec/classes/php_repo_ubuntu_spec.rb
@@ -12,9 +12,18 @@ describe 'php::repo::ubuntu', type: :class do
       describe 'works without params' do
         if facts[:os]['name'] == 'Ubuntu'
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_apt__ppa('ppa:ondrej/php') }
+          it { is_expected.to contain_apt__keyring('packages-sury-org.gpg') }
+          it { is_expected.to contain_apt__source('source_php_sury') }
         else
           it { is_expected.to compile.and_raise_error(%r{class php::repo::ubuntu does not work on OS}) }
+        end
+      end
+
+      describe 'fails when version is specified' do
+        if facts[:os]['name'] == 'Ubuntu'
+          let(:params) { { version: '8.1' } }
+
+          it { is_expected.to compile.and_raise_error(%r{version parameter has been removed}) }
         end
       end
     end


### PR DESCRIPTION
As described in #763 and https://codeberg.org/oerdnj/deb.sury.org/issues/73, the PHP package repository maintained by Ondřej Surý will move from a PPA to packages.sury.org.

Ubuntu 26.04 packages are available in the new location only, see https://codeberg.org/oerdnj/deb.sury.org/issues/91.